### PR TITLE
Use (void) x instead of x = x to mark unused variables.

### DIFF
--- a/src/output.h
+++ b/src/output.h
@@ -82,7 +82,7 @@ void output_report_banner(
 #if defined(_MSC_VER)
 #define UNUSEDPARM(x) x
 #else
-#define UNUSEDPARM(x) (x)=(x)
+#define UNUSEDPARM(x) (void) x
 #endif
 #endif
 

--- a/src/proto-ssh.c
+++ b/src/proto-ssh.c
@@ -1,5 +1,6 @@
 #include "proto-ssh.h"
 #include "proto-banner1.h"
+#include "unusedparm.h"
 #include <ctype.h>
 
 
@@ -13,7 +14,7 @@ banner_ssh(  struct Banner1 *banner1,
 {
     unsigned i;
 
-    banner1=banner1;
+    UNUSEDPARM(banner1);
 
     for (i=0; i<length; i++)
     switch (state) {

--- a/src/unusedparm.h
+++ b/src/unusedparm.h
@@ -2,6 +2,6 @@
 #if defined(_MSC_VER)
 #define UNUSEDPARM(x) x
 #elif defined(__GNUC__)
-#define UNUSEDPARM(x)
+#define UNUSEDPARM(x) (void) x
 #endif
 #endif


### PR DESCRIPTION
Not a big deal, but x = x makes clang, and maybe other static analyzers whine about assigning a variable to itself.
