### PR TITLE
Fix netop.org -> ntop.org URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ systems. Here's some additional build info:
 ## PF_RING
 
 To get beyond 2 million packets/second, you need an Intel 10-gbps Ethernet
-adapter and a special driver known as "PF_RING DNA" from http://www.netop.org.
+adapter and a special driver known as "PF_RING DNA" from http://www.ntop.org/products/pf_ring/.
 Masscan doesn't need to be rebuilt in order to use PF_RING. To use PF_RING,
 you need to build the following components:
 * `libpfring.so` (installed in /usr/lib/libpfring.so)


### PR DESCRIPTION
Netop.org is owned by a domain squatter, this fixes the link to take people to PF_RING information.
