### PR TITLE
Add local and reserved ranges to exclude file.

### DIFF
--- a/data/exclude.conf
+++ b/data/exclude.conf
@@ -1,3 +1,43 @@
+# http://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
+# http://tools.ietf.org/html/rfc5735
+# "This" network
+0.0.0.0/8
+# Private networks
+10.0.0.0/8
+# Carrier-grade NAT - RFC 6598
+100.64.0.0/10
+# Host loopback
+127.0.0.0/8
+# Link local
+169.254.0.0/16
+# Private networks
+172.16.0.0/12
+# IETF Protocol Assignments
+192.0.0.0/24
+# DS-Lite
+192.0.0.0/29
+# NAT64
+192.0.0.170/32
+# DNS64
+192.0.0.171/32
+# Documentation (TEST-NET-1)
+192.0.2.0/24
+# 6to4 Relay Anycast
+192.88.99.0/24
+# Private networks
+192.168.0.0/16
+# Benchmarking
+198.18.0.0/15
+# Documentation (TEST-NET-2)
+198.51.100.0/24
+# Documentation (TEST-NET-3)
+203.0.113.0/24
+# Reserved
+240.0.0.0/4
+# Limited Broadcast
+255.255.255.255/32
+
+
 #Received: from elbmasnwh002.us-ct-eb01.gdeb.com ([153.11.13.41]
 # helo=ebsmtp.gdeb.com)	by mx1.gd-ms.com with esmtp (Exim 4.76)	(envelope-from
 # <bmandes@gdeb.com>)	id 1VS55c-0004qL-0F	for support@erratasec.com; Fri, 04


### PR DESCRIPTION
Since this tool is generally interested in scanning the internet, and not the localnet, add RFC 5735 ranges to the default excludes file.
