### PR TITLE
add Freebsd support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,13 @@ INCLUDES = -I.
 FLAGS2 = 
 endif
 
+# FreeBSD
+ifneq (, $(findstring freebsd, $(SYS)))
+LIBS = -lpcap -lm -pthread
+INCLUDES = -I.
+FLAGS2 =
+endif
+
 # this works on llvm or real gcc
 CC = gcc
 


### PR DESCRIPTION
Adding entry to build masscan, and work on FreeBSD.
I have done regression test on my freebsd box, following.

% uname -a
FreeBSD arty 10.0-CURRENT FreeBSD 10.0-CURRENT #1 r255168: Tue Sep  3 19:27:55 JST 2013     user@arty:/usr/obj/usr/src/sys/ARTY  amd64

% gmake regress
bin/masscan --selftest
regression test: success!
