### PR TITLE
Set TCP window size to 1024 in template pkt to avoid detection

### DIFF
--- a/src/templ-pkt.c
+++ b/src/templ-pkt.c
@@ -42,9 +42,10 @@ static unsigned char default_tcp_template[] =
     "\0\0\0\0"      /* ack number */
     "\x50"          /* header length */
     "\x02"          /* SYN */
-    "\x0\x0"        /* window */
+    "\x04\x0"        /* window fixed to 1024 */
     "\xFF\xFF"      /* checksum */
     "\x00\x00"      /* urgent pointer */
+    "\x02\x04\x05\xb4"  /* added options [mss 1460] */
 ;
 
 static unsigned char default_udp_template[] =


### PR DESCRIPTION
Hi, as suggested in open issue "Fix TCP winsize in templ-pkt.c to avoid detection" set a real TCP window size to avoid easy scan detection.
Also added minimal TCP options to template, but it get lost in generated pkt ( probably need other changes somewhere in code to take care of extra bytes..)

Regards,
