### PR TITLE
Small change for better seed and randomness.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1377,7 +1377,7 @@ int main(int argc, char *argv[])
      * Initialize those defaults that aren't zero
      */
     memset(masscan, 0, sizeof(*masscan));
-    masscan->seed = time(0); /* a predictable, but 'random' seed */
+    masscan->seed = get_entropy(); /* entropy for randomness */
     masscan->wait = 10; /* how long to wait for responses when done */
     masscan->max_rate = 100.0; /* max rate = hundred packets-per-second */
     masscan->nic_count = 1;

--- a/src/syn-cookie.c
+++ b/src/syn-cookie.c
@@ -15,18 +15,10 @@
  * NOTE: Mostly it's here to amuse cryptographers with its lulz.
  ***************************************************************************/
 uint64_t
-syn_get_entropy(uint64_t seed)
+get_entropy(void)
 {
     uint64_t entropy[2] = {0,0};
     unsigned i;
-
-    /*
-     * If we have a manual seed, use that instead
-     */
-    if (seed) {
-        entropy[0] = seed;
-        return seed;
-    }
 
     /*
      * Gather some random bits

--- a/src/syn-cookie.h
+++ b/src/syn-cookie.h
@@ -15,7 +15,7 @@ syn_cookie( unsigned ip_dst, unsigned port_dst,
 /**
  * Called on startup to set a secret key
  */
-uint64_t syn_get_entropy(uint64_t seed);
+uint64_t get_entropy(void);
 
 
 #endif


### PR DESCRIPTION
Since we are not using 'syn_get_entropy(uint64_t seed)', it's changed to return more better entropy for seed than 'time(NULL)'.
