### PR TITLE
Fixed the Mac OS X install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PREFIX ?= /usr
 BINDIR ?= $(PREFIX)/bin
 SYS := $(shell gcc -dumpmachine)
 GITVER := $(shell git describe --tags)
+INSTALL_DATA := -pDm755
 
 ifeq ($(GITVER),)
 GITVER = "unknown"
@@ -25,6 +26,7 @@ ifneq (, $(findstring darwin, $(SYS)))
 LIBS = -lpcap -lm -rdynamic
 INCLUDES = -I.
 FLAGS2 = 
+INSTALL_DATA = -pm755
 endif
 
 # MinGW on Windows
@@ -100,6 +102,6 @@ regress: bin/masscan
 	bin/masscan --selftest
 
 install: bin/masscan
-	install -pDm755 bin/masscan $(DESTDIR)$(BINDIR)/masscan
+	install $(INSTALL_DATA) bin/masscan $(DESTDIR)$(BINDIR)/masscan
 	
 default: bin/masscan


### PR DESCRIPTION
Mac OS X install does not have the -D option.
Added the INSTALL_DATA variable as suggested in
http://www.gnu.org/prep/standards/html_node/Command-Variables.html
