### PR TITLE
Fix sharding with multiple NICs / threads

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -269,7 +269,7 @@ transmit_thread(void *v) /*aka. scanning_thread() */
     unsigned *picker = parms->picker;
     struct Adapter *adapter = parms->adapter;
     uint64_t packets_sent = 0;
-    unsigned increment = (masscan->shard.of-1) + masscan->nic_count;
+    unsigned increment = (masscan->shard.of) * masscan->nic_count;
     unsigned src_ip;
     unsigned src_ip_mask;
     unsigned src_port;
@@ -315,7 +315,7 @@ infinite:
      * a little bit past the end when we have --retries. Yet another
      * thing to do here is deal with multiple network adapters, which
      * is essentially the same logic as shards. */
-    start = masscan->resume.index + (masscan->shard.one-1) + parms->nic_index;
+    start = masscan->resume.index + (masscan->shard.one-1) + (parms->nic_index * masscan->shard.of);
     end = range;
     if (masscan->resume.count && end > start + masscan->resume.count)
         end = start + masscan->resume.count;


### PR DESCRIPTION
Previously, sharding with multiple NICs resulted in number_of_shards +
number_of_nics total shards, rather than splitting up the current shard
by number_of_nics.

For example, --shard=1/50 on a system with two NICs would result in an
increment of 52 (50 + 2), when instead what you really want is an
increment of 100, offset by 50 on each NIC, e.g. NIC 0 starts at 0, NIC
1 starts at 50, both increment by 100.

Luckily, the old implementation didn't result any any single instance of
masscan scanning any host more than once, but if all shards were
distributed across multiple hosts/scans, certain shards would be
overlapped, e.g. --shard=1/50 would scan shards 1 and 2, --shard=2/50
would scan shards 2 and 3, etc. It also would result in errors when
random sampling, as more address would be scanned than expected with a
single shard, e.g. when scanning 1 of 50 shards you would not get a 2%
sample.
