### PR TITLE
Ensure fclose just in case code is run on non *NIX systems

### DIFF
--- a/src/syn-cookie.c
+++ b/src/syn-cookie.c
@@ -19,6 +19,7 @@ get_entropy(void)
 {
     uint64_t entropy[2] = {0,0};
     unsigned i;
+    int err;
 
     /*
      * Gather some random bits
@@ -30,10 +31,13 @@ get_entropy(void)
         entropy[0] ^= __rdtsc();
 #endif
         time(0);
-        fopen_s(&fp, "/", "r");
+        err = fopen_s(&fp, "/", "r");
         entropy[1] <<= 1;
         entropy[1] |= entropy[0]>>63;
         entropy[0] <<= 1;
+        if (err == 0 && fp) {
+            fclose(fp);
+        }
     }
 
     entropy[0] ^= time(0);
@@ -41,7 +45,6 @@ get_entropy(void)
 #if defined(__linux__)
     {
         FILE *fp;
-        int err;
 
         err = fopen_s(&fp, "/dev/urandom", "r");
         if (err == 0 && fp) {


### PR DESCRIPTION
Addressing issue #99.
If this code is run on systems without *NIX environments and for which "/" could be a file and not a directory, an fclose call is needed.
