### PR TITLE
Tiny fix to make masscan compile under vs2010

### DIFF
--- a/src/proto-ssl.c
+++ b/src/proto-ssl.c
@@ -787,7 +787,7 @@ parse_alert(
         DESCRIPTION,
         UNKNOWN,
     };
-    
+	char foo[64];    
     UNUSEDPARM(more);
     UNUSEDPARM(banner1_private);
     
@@ -819,7 +819,6 @@ parse_alert(
                         default:
                             banout_append(banout, PROTO_SAFE, 
                                           "poodle[no-SSLv3] ", AUTO_LEN);
-                            char foo[64];
                             sprintf_s(foo, sizeof(foo), " ALERT(0x%02x%02x) ",
                                       ssl->x.server_alert.level,
                                       ssl->x.server_alert.description
@@ -829,7 +828,7 @@ parse_alert(
                             break;
                     }
                 } else {
-                    char foo[64];
+
                     sprintf_s(foo, sizeof(foo), " ALERT(0x%02x%02x) ",
                               ssl->x.server_alert.level,
                               ssl->x.server_alert.description


### PR DESCRIPTION
A tiny fix to make VS compiler happy - it doesn't like variables declared in the middle of a function.
