### PR TITLE
Switch debian/license to standard AGPL

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -5,13 +5,7 @@ Source: https://github.com/robertdavidgraham/masscan
 Files: *
 Copyright: 2013 Robert David Graham <robert_david_graham@yahoo.com>
 License: AGPL
- This program, "masscan", is not completely free software. It may not be
- used by the United States Department of Defense (DoD) or National Security
- Agency (NSA), or by agents acting on their behalf, such as contractors,
- sub-contractors, and so on. These entitities must contact me to acquire
- a different license.
- .
- Barring the above exception, you can use, redistribute, and/or modify
+ You can use, redistribute, and/or modify
  this code under the terms of the GNU Affero General Public License
  version 3.
  .


### PR DESCRIPTION
The ./LICENSE file was updated to standard AGPL in commit 3bd62348a746e4bd51c2e17445a30cedd2482af0 but debian/copyright was not updated at the time. This change is to sync up debian/copyright to prevent any confusion around licensing.
