### PR TITLE
Remove double call to fclose()

### DIFF
--- a/src/templ-payloads.c
+++ b/src/templ-payloads.c
@@ -681,7 +681,7 @@ payloads_read_file(FILE *fp, const char *filename,
 #endif
 
 end:
-    fclose(fp);
+    return;
 }
 
 /***************************************************************************


### PR DESCRIPTION
Called from within payloads_read_file, then outside from main-conf.c; double free condition