### PR TITLE
UDP ports --echo out properly

### DIFF
--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -368,6 +368,11 @@ masscan_echo(struct Masscan *masscan, FILE *fp)
     fprintf(fp, "ports = ");
     for (i=0; i<masscan->ports.count; i++) {
         struct Range range = masscan->ports.list[i];
+        if (range.begin > 0xFFFF){ // UDP
+            range.begin -= 0x10000;
+            range.end   -= 0x10000;
+            fprintf(fp, "U:");
+        }
         if (range.begin == range.end)
             fprintf(fp, "%u", range.begin);
         else


### PR DESCRIPTION
masscan expects U:<port>, not <port>+0x10000.   this patch makes the --echo output readable as input for UDP ports.
### before:

```
$ masscan -p22,U:123,U:161-162 --echo | grep ports
ports = 22,65659,65697-65698
```
### after:

```
masscan -p22,U:123 --echo | grep ports
ports = 22,U:123,U:161-162
```
