### PR TITLE
Fix FTBFS on most Debian architectures

### DIFF
--- a/src/pixie-threads.c
+++ b/src/pixie-threads.c
@@ -180,7 +180,7 @@ pixie_begin_thread(
 #if defined(WIN32)
     UNUSEDPARM(flags);
     return _beginthread(worker_thread, 0, worker_data);
-#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__kFreeBSD__) || defined(__OpenBSD__)
 
     typedef void *(*PTHREADFUNC)(void*);
     pthread_t thread_id;

--- a/src/pixie-threads.h
+++ b/src/pixie-threads.h
@@ -40,7 +40,7 @@ void pixie_locked_subtract_u32(unsigned *lhs, unsigned rhs);
 #define pixie_locked_CAS32(dst, src, expected) __sync_bool_compare_and_swap((volatile int*)(dst),(int)expected,(int)src);
 #define pixie_locked_CAS64(dst, src, expected) __sync_bool_compare_and_swap((volatile long long int*)(dst),(long long int)expected,(long long int)src);
 
-#if defined(__arm__)
+#if !defined(__x86_64__) && !defined(__i386__)
 #define rte_wmb() __sync_synchronize()
 #define rte_rmb() __sync_synchronize()
 #define rte_pause()


### PR DESCRIPTION
Fixes Debian#773786 and enables support on non-ARM,
Non-x86, and kFreeBSD architectures.