### PR TITLE
Fix build failure with GCC 5

### DIFF
--- a/src/string_s.h
+++ b/src/string_s.h
@@ -77,7 +77,7 @@ const char *strerror_x(int x);
  typedef int errno_t;
 errno_t fopen_s(FILE **fp, const char *filename, const char *mode);
 
-#elif defined(__GNUC__) && (__GNUC__ == 4)
+#elif defined(__GNUC__) && (__GNUC__ >= 4)
 #include <inttypes.h>
 /* GCC 4 */
 # define sprintf_s      snprintf


### PR DESCRIPTION
Patch applied in Debian to solve FTBFS with the GCC's new version. The original bug report is available here:
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=777997

Thanks for considering.