### PR TITLE
Added a header to represent some config options in binary output

### DIFF
--- a/src/out-binary.c
+++ b/src/out-binary.c
@@ -14,10 +14,20 @@ binary_out_open(struct Output *out, FILE *fp)
 
     UNUSEDPARM(out);
 
-
     memset(firstrecord, 0, 2+'a');
-    sprintf_s(firstrecord, 2+'a', "masscan/1.1.02\ns:%u\n", 
-        (unsigned)out->when_scan_started);
+    sprintf_s(firstrecord, 2+'a', "masscan/1.1.02\ns:%u\ni:%u\n", 
+        (unsigned)out->when_scan_started,
+	(unsigned)((out->is_gmt ? 1<<31 : 0)
+			|(out->is_show_host ? 1<<19 : 0)
+			|(out->is_show_closed ? 1<<18 : 0)
+			|(out->is_show_open ? 1<<17 : 0)
+			|(out->is_banner ? 1<<16 : 0)
+			|(out->is_capture_html ? 1<<15 : 0)
+			|(out->is_capture_cert ? 1<<14 : 0)
+			|(out->is_capture_heartbleed ? 1<<13 : 0)
+			|(out->is_heartbleed ? 1<<7 : 0)
+			|(out->is_poodle_sslv3 ? 1<<6 : 0))
+	);
     bytes_written = fwrite(firstrecord, 1, 2+'a', fp);
     if (bytes_written != 2+'a') {
         perror("output");

--- a/src/output.c
+++ b/src/output.c
@@ -403,6 +403,11 @@ output_create(const struct Masscan *masscan, unsigned thread_index)
     out->is_show_closed = masscan->output.is_show_closed;
     out->is_show_host = masscan->output.is_show_host;
     out->is_append = masscan->output.is_append;
+    out->is_capture_html = masscan->is_capture_html;
+    out->is_capture_cert = masscan->is_capture_cert;
+    out->is_capture_heartbleed = masscan->is_capture_heartbleed;
+    out->is_heartbleed = masscan->is_heartbleed;
+    out->is_poodle_sslv3 = masscan->is_poodle_sslv3;
     out->xml.stylesheet = duplicate_string(masscan->output.stylesheet);
     out->rotate.directory = duplicate_string(masscan->output.rotate.directory);
     if (masscan->nic_count <= 1)

--- a/src/output.h
+++ b/src/output.h
@@ -79,6 +79,11 @@ struct Output
     unsigned is_show_closed:1; /* show closed ports */
     unsigned is_show_host:1; /* show host status info, like up/down */
     unsigned is_append:1; /* append to file */
+    unsigned is_capture_html:1;
+    unsigned is_capture_cert:1;
+    unsigned is_capture_heartbleed:1;
+    unsigned is_heartbleed:1;
+    unsigned is_poodle_sslv3:1; 
     struct {
         struct {
             uint64_t open;


### PR DESCRIPTION
This is useful when working with a collection of scans from various sources