### PR TITLE
Add timestamp to json output format

### DIFF
--- a/src/out-json.c
+++ b/src/out-json.c
@@ -100,9 +100,11 @@ json_out_banner(struct Output *out, FILE *fp, time_t timestamp,
     char banner_buffer[65536];
 
     UNUSEDPARM(ttl);
-    UNUSEDPARM(timestamp);
     
     fprintf(fp, "{ ");
+    fprintf(fp, "  \"timestamp\": \"%s\", ", 
+		timestamp
+	   );
     fprintf(fp, "  \"ip\": \"%u.%u.%u.%u\", ", 
             (ip>>24)&0xFF, (ip>>16)&0xFF, (ip>> 8)&0xFF, (ip>> 0)&0xFF);
     fprintf(fp, "  \"ports\": [ {\"port\": %u, \"proto\": \"%s\", \"service\": {\"name\": \"%s\", \"banner\": \"%s\"} } ] ",

--- a/src/out-json.c
+++ b/src/out-json.c
@@ -35,7 +35,7 @@ json_out_status(struct Output *out, FILE *fp, time_t timestamp, int status,
     UNUSEDPARM(out);
     
     fprintf(fp, "{ ");
-    fprintf(fp, "  \"timestamp\": \"%s\", ", 
+    fprintf(fp, "  \"timestamp\": \"%lu\", ", 
 		timestamp
 	   );
     fprintf(fp, "  \"ip\": \"%u.%u.%u.%u\", ", 
@@ -102,7 +102,7 @@ json_out_banner(struct Output *out, FILE *fp, time_t timestamp,
     UNUSEDPARM(ttl);
     
     fprintf(fp, "{ ");
-    fprintf(fp, "  \"timestamp\": \"%s\", ", 
+    fprintf(fp, "  \"timestamp\": \"%lu\", ", 
 		timestamp
 	   );
     fprintf(fp, "  \"ip\": \"%u.%u.%u.%u\", ", 

--- a/src/out-json.c
+++ b/src/out-json.c
@@ -33,9 +33,11 @@ json_out_status(struct Output *out, FILE *fp, time_t timestamp, int status,
 {
     char reason_buffer[128];
     UNUSEDPARM(out);
-    UNUSEDPARM(timestamp);
     
     fprintf(fp, "{ ");
+    fprintf(fp, "  \"timestamp\": \"%s\", ", 
+		timestamp
+	   );
     fprintf(fp, "  \"ip\": \"%u.%u.%u.%u\", ", 
             (ip>>24)&0xFF, (ip>>16)&0xFF, (ip>> 8)&0xFF, (ip>> 0)&0xFF);
     fprintf(fp, "  \"ports\": [ {\"port\": %u, \"proto\": \"%s\", \"status\": \"%s\","


### PR DESCRIPTION
Timestamp is information useful for me, and is present in other formats (such as XML). This patch adds the timestamp in as the first field (useful for Splunking the resulting data)
