### PR TITLE
Various fixes involving port handling and resumption

### DIFF
--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -365,6 +365,7 @@ masscan_echo(struct Masscan *masscan, FILE *fp)
     }
 
     fprintf(fp, "# TARGET SELECTION (IP, PORTS, EXCLUDES)\n");
+    fprintf(fp, "retries = %u\n", masscan->retries);
     fprintf(fp, "ports = ");
     for (i=0; i<masscan->ports.count; i++) {
         struct Range range = masscan->ports.list[i];

--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -1280,6 +1280,10 @@ masscan_set_parameter(struct Masscan *masscan,
         masscan->output.is_interactive = 1;
     } else if (EQUALS("nointeractive", name)) {
         masscan->output.is_interactive = 0;
+    } else if (EQUALS("status", name)) {
+        masscan->output.status_updates = 1;
+    } else if (EQUALS("nostatus", name)) {
+        masscan->output.status_updates = 0;
     } else if (EQUALS("ip-options", name)) {
         fprintf(stderr, "nmap(%s): unsupported: maybe soon\n", name);
         exit(1);
@@ -1649,7 +1653,7 @@ is_singleton(const char *name)
         "nmap", "trace-packet", "pfring", "sendq",
         "banners", "banner", "nobanners", "nobanner",
         "offline", "ping", "ping-sweep",
-        "arp",  "infinite", "interactive",
+        "arp",  "infinite", "nointeractive", "interactive", "status", "nostatus",
         "read-range", "read-ranges", "readrange", "read-ranges",
         0};
     size_t i;

--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -26,6 +26,8 @@
 #include <ctype.h>
 #include <limits.h>
 
+#define min(a,b) ((a)<(b)?(a):(b))
+
 /***************************************************************************
  ***************************************************************************/
 /*static struct Range top_ports_tcp[] = {
@@ -290,6 +292,7 @@ static void
 masscan_echo(struct Masscan *masscan, FILE *fp)
 {
     unsigned i;
+    unsigned l = 0;
 
     fprintf(fp, "rate = %10.2f\n", masscan->max_rate);
     fprintf(fp, "randomize-hosts = true\n");
@@ -355,26 +358,44 @@ masscan_echo(struct Masscan *masscan, FILE *fp)
      * Targets
      */
 
-    for (i=0; i<masscan->ports.count; i++) {
-	struct Range range = masscan->ports.list[i];
-	if ( (range.begin == range.end) && (range.begin == Templ_ICMP_echo) )
-		{
-		fprintf(fp,"ping = true\n");
-		break;
-		}
-    }
-
     fprintf(fp, "# TARGET SELECTION (IP, PORTS, EXCLUDES)\n");
     fprintf(fp, "retries = %u\n", masscan->retries);
     fprintf(fp, "ports = ");
+    /* Disable comma generation for the first element */
+    l = 0;
     for (i=0; i<masscan->ports.count; i++) {
         struct Range range = masscan->ports.list[i];
-        if (range.begin == range.end)
-            fprintf(fp, "%u", range.begin);
-        else
-            fprintf(fp, "%u-%u", range.begin, range.end);
-        if (i+1 < masscan->ports.count)
-            fprintf(fp, ",");
+        do {
+            struct Range rrange = range;
+            unsigned done = 0;
+            if (l)
+                fprintf(fp, ",");
+            l = 1;
+            if (rrange.begin >= Templ_ICMP_echo) {
+                rrange.begin -= Templ_ICMP_echo;
+                rrange.end -= Templ_ICMP_echo;
+                fprintf(fp,"I:");
+                done = 1;
+            } else if (rrange.begin >= Templ_SCTP) {
+                rrange.begin -= Templ_SCTP;
+                rrange.end -= Templ_SCTP;
+                fprintf(fp,"S:");
+                range.begin = Templ_ICMP_echo;
+            } else if (rrange.begin >= Templ_UDP) {
+                rrange.begin -= Templ_UDP;
+                rrange.end -= Templ_UDP;
+                fprintf(fp,"U:");
+                range.begin = Templ_SCTP;
+            } else
+                range.begin = Templ_UDP;
+            rrange.end = min(rrange.end, 65535);
+            if (rrange.begin == rrange.end)
+                fprintf(fp, "%u", rrange.begin);
+            else
+                fprintf(fp, "%u-%u", rrange.begin, rrange.end);
+            if (done)
+                break;
+        } while (range.begin <= range.end);
     }
     fprintf(fp, "\n");
     for (i=0; i<masscan->targets.count; i++) {

--- a/src/main-globals.h
+++ b/src/main-globals.h
@@ -2,7 +2,8 @@
 #define MAIN_GLOBALS_H
 #include <time.h>
 
-extern unsigned control_c_pressed;
+extern unsigned volatile tx_done;
+extern unsigned volatile rx_done;
 extern time_t global_now;
 
 

--- a/src/main-status.c
+++ b/src/main-status.c
@@ -139,7 +139,7 @@ status_print(
                         total_tcbs
                         );
     } else {
-        if (control_c_pressed) {
+        if (tx_done) {
             fprintf(stderr,
                 "rate:%6.2f-kpps, %5.2f%% done, waiting %d-secs, found=%" PRIu64 "       \r",
                         x/1000.0,

--- a/src/main.c
+++ b/src/main.c
@@ -1291,9 +1291,10 @@ main_scan(struct Masscan *masscan)
          * update screen about once per second with statistics,
          * namely packets/second.
          */
-        status_print(&status, min_index, range, rate,
-            total_tcbs, total_synacks, total_syns,
-            0);
+        if (masscan->output.status_updates)
+            status_print(&status, min_index, range, rate,
+                total_tcbs, total_synacks, total_syns,
+                0);
 
         /* Sleep for almost a second */
         pixie_mssleep(750);
@@ -1345,9 +1346,10 @@ main_scan(struct Masscan *masscan)
         }
 
 
-        status_print(&status, min_index, range, rate,
-            total_tcbs, total_synacks, total_syns,
-            masscan->wait - (time(0) - now));
+        if (masscan->output.status_updates)
+            status_print(&status, min_index, range, rate,
+                total_tcbs, total_synacks, total_syns,
+                masscan->wait - (time(0) - now));
 
         if (time(0) - now >= masscan->wait)
             control_c_pressed_again = 1;
@@ -1407,6 +1409,7 @@ int main(int argc, char *argv[])
     memset(masscan, 0, sizeof(*masscan));
     masscan->blackrock_rounds = 4;
     masscan->output.is_show_open = 1; /* default: show syn-ack, not rst */
+    masscan->output.status_updates = 1; /* default: show status updates */
     masscan->seed = get_entropy(); /* entropy for randomness */
     masscan->wait = 10; /* how long to wait for responses when done */
     masscan->max_rate = 100.0; /* max rate = hundred packets-per-second */

--- a/src/main.c
+++ b/src/main.c
@@ -77,8 +77,8 @@
 /*
  * yea I know globals suck
  */
-unsigned control_c_pressed = 0;
-static unsigned control_c_pressed_again = 0;
+unsigned volatile tx_done = 0;
+unsigned volatile rx_done = 0;
 time_t global_now;
 
 
@@ -441,7 +441,7 @@ infinite:
         /* If the user pressed <ctrl-c>, then we need to exit. but, in case
          * the user wants to --resume the scan later, we save the current
          * state in a file */
-        if (control_c_pressed) {
+        if (tx_done) {
             break;
         }
     }
@@ -450,7 +450,7 @@ infinite:
      * --infinite
      *  For load testing, go around and do this again
      */
-    if (masscan->is_infinite && !control_c_pressed) {
+    if (masscan->is_infinite && !tx_done) {
         seed++;
         repeats++;
         goto infinite;
@@ -468,7 +468,7 @@ infinite:
      * Wait until the receive thread realizes the scan is over
      */
     LOG(1, "Transmit thread done, waiting for receive thread to realize this\n");
-    while (!control_c_pressed)
+    while (!tx_done)
         pixie_usleep(1000);
 
     /*
@@ -477,7 +477,7 @@ infinite:
      * packets to arrive. Pressing <ctrl-c> a second time will exit this
      * prematurely.
      */
-    while (!control_c_pressed_again) {
+    while (!rx_done) {
         unsigned k;
         uint64_t batch_size;
 
@@ -661,7 +661,7 @@ receive_thread(void *v)
      * wait until transmitter thread is done then go to the end
      */
     if (masscan->is_offline) {
-        while (!control_c_pressed_again)
+        while (!rx_done)
             pixie_usleep(10000);
         parms->done_receiving = 1;
         goto end;
@@ -672,7 +672,7 @@ receive_thread(void *v)
      * them to the terminal.
      */
     LOG(1, "begin receive thread\n");
-    while (!control_c_pressed_again) {
+    while (!rx_done) {
         int status;
         unsigned length;
         unsigned secs;
@@ -1005,6 +1005,8 @@ end:
  ***************************************************************************/
 static void control_c_handler(int x)
 {
+    static unsigned control_c_pressed = 0;
+    static unsigned control_c_pressed_again = 0;
     if (control_c_pressed == 0) {
         fprintf(stderr,
                 "waiting several seconds to exit..."
@@ -1012,8 +1014,11 @@ static void control_c_handler(int x)
                 );
         fflush(stderr);
         control_c_pressed = 1+x;
-    } else
+        tx_done = control_c_pressed;
+    } else {
         control_c_pressed_again = 1;
+        rx_done = control_c_pressed_again;
+    }
 
 }
 
@@ -1256,7 +1261,7 @@ main_scan(struct Masscan *masscan)
      */
     status_start(&status);
     status.is_infinite = masscan->is_infinite;
-    while (!control_c_pressed) {
+    while (!tx_done) {
         unsigned i;
         double rate = 0;
         uint64_t total_tcbs = 0;
@@ -1284,7 +1289,7 @@ main_scan(struct Masscan *masscan)
 
         if (min_index >= range && !masscan->is_infinite) {
             /* Note: This is how we can tell the scan has ended */
-            control_c_pressed = 1;
+            tx_done = 1;
         }
 
         /*
@@ -1352,7 +1357,7 @@ main_scan(struct Masscan *masscan)
                 masscan->wait - (time(0) - now));
 
         if (time(0) - now >= masscan->wait)
-            control_c_pressed_again = 1;
+            rx_done = 1;
 
         for (i=0; i<masscan->nic_count; i++) {
             struct ThreadPair *parms = &parms_array[i];
@@ -1366,8 +1371,8 @@ main_scan(struct Masscan *masscan)
 
         if (transmit_count < masscan->nic_count)
             continue;
-        control_c_pressed = 1;
-        control_c_pressed_again = 1;
+        tx_done = 1;
+        rx_done = 1;
         if (receive_count < masscan->nic_count)
             continue;
         break;

--- a/src/masscan.h
+++ b/src/masscan.h
@@ -177,7 +177,6 @@ struct Masscan
     unsigned is_heartbleed:1;   /* --heartbleed, scan for this vuln */
     unsigned is_poodle_sslv3:1; /* --script poodle, scan for this vuln */
         
-
     /**
      * Wait forever for responses, instead of the default 10 seconds
      */
@@ -295,6 +294,11 @@ struct Masscan
          */
         unsigned is_interactive:1;
         
+        /**
+        * Print state updates
+        */
+        unsigned status_updates:1;
+
         struct {
             /**
              * When we should rotate output into the target directory

--- a/src/output.c
+++ b/src/output.c
@@ -206,7 +206,7 @@ open_rotate(struct Output *out, const char *filename)
             fprintf(stderr, "out: could not open file for %s\n",
                     is_append?"appending":"writing");
             perror(filename);
-            control_c_pressed = 1;
+            tx_done = 1;
             return NULL;
         }
     }

--- a/src/rawsock.c
+++ b/src/rawsock.c
@@ -367,7 +367,7 @@ int rawsock_recv_packet(
                         );
         if (err == PF_RING_ERROR_NO_PKT_AVAILABLE || hdr.caplen == 0) {
             PFRING.poll(adapter->ring, 1);
-            if (control_c_pressed)
+            if (tx_done)
                 return 1;
             goto again;
         }


### PR DESCRIPTION
32dfd86 adds an extra parameter which prevents masscan from sending status updates to the output to simplify automated handling
ff34bb0 prevents masscan from closing when waiting for the last packets if it has yet to receive a SIGINT, this prevents a race condition where the user may send a SIGINT before realizing this.
32bd94b echoes the number of retries in paused.conf as otherwise the user will get bogus results on resumption
a43ab2b fixes issues with the echoing of ports to paused.conf
