### PR TITLE
Include <status> element in nmap XML output, required by nmap DTD

### DIFF
--- a/src/out-xml.c
+++ b/src/out-xml.c
@@ -69,6 +69,7 @@ xml_out_status(struct Output *out, FILE *fp, time_t timestamp, int status,
     char reason_buffer[128];
     UNUSEDPARM(out);
     fprintf(fp, "<host endtime=\"%u\">"
+                    "<status state=\"up\" reason=\"port-%s\" reason_ttl=\"%u\"/>"
                     "<address addr=\"%u.%u.%u.%u\" addrtype=\"ipv4\"/>"
                     "<ports>"
                     "<port protocol=\"%s\" portid=\"%u\">"
@@ -78,6 +79,7 @@ xml_out_status(struct Output *out, FILE *fp, time_t timestamp, int status,
                 "</host>"
                 "\r\n",
         (unsigned)timestamp,
+        status_string(status), ttl,
         (ip>>24)&0xFF,
         (ip>>16)&0xFF,
         (ip>> 8)&0xFF,
@@ -95,7 +97,7 @@ xml_out_status(struct Output *out, FILE *fp, time_t timestamp, int status,
 static void
 xml_out_banner(struct Output *out, FILE *fp, time_t timestamp,
         unsigned ip, unsigned ip_proto, unsigned port,
-        enum ApplicationProtocol proto, 
+        enum ApplicationProtocol proto,
         unsigned ttl,
         const unsigned char *px, unsigned length)
 {
@@ -110,6 +112,7 @@ xml_out_banner(struct Output *out, FILE *fp, time_t timestamp,
     UNUSEDPARM(out);
 
     fprintf(fp, "<host endtime=\"%u\">"
+                    "<status state=\"up\" reason=\"port-%s\" reason_ttl=\"%u\"/>"
                     "<address addr=\"%u.%u.%u.%u\" addrtype=\"ipv4\"/>"
                     "<ports>"
                     "<port protocol=\"%s\" portid=\"%u\">"
@@ -120,6 +123,7 @@ xml_out_banner(struct Output *out, FILE *fp, time_t timestamp,
                 "</host>"
                 "\r\n",
         (unsigned)timestamp,
+        reason, ttl,
         (ip>>24)&0xFF,
         (ip>>16)&0xFF,
         (ip>> 8)&0xFF,


### PR DESCRIPTION
At least in my testing this fixes #100, more specifically it allows metasploit to import masscan XML output.  The `reason` and `reason_ttl` I'm adding because they are also required according to https://github.com/nmap/nmap/blob/master/docs/nmap.dtd#L138-L159, but I admittedly don't like that they are here.
