### PR TITLE
Update masscan.8 and masscan.8.markdown

### DIFF
--- a/doc/masscan.8
+++ b/doc/masscan.8
@@ -72,7 +72,7 @@ masscan <ip addresses/ranges> \-p \fIports\fR \fIoptions\fR
 \fB\-\-retries\fR: the number of retries to send, at 1 second intervals\. Note that since this scanner is stateless, retries are sent regardless if replies have already been received\.
 .
 .IP "\(bu" 4
-\fB\-\-nmap\fR: print help aobut nmap\-compatibility alternatives for these options\.
+\fB\-\-nmap\fR: print help about nmap\-compatibility alternatives for these options\.
 .
 .IP "\(bu" 4
 \fB\-\-pcap\-payloads\fR: read packets from a libpcap file containing packets and extract the UDP payloads, and associate those payloads with the destination port\. These payloads will then be used when sending UDP packets with the matching destination port\. Only one payload will be remembered per port\. Similar to \fB\-\-nmap\-payloads\fR\.

--- a/doc/masscan.8.markdown
+++ b/doc/masscan.8.markdown
@@ -111,7 +111,7 @@ one port.
     that since this scanner is stateless, retries are sent regardless if
 	replies have already been received.
 
-  * `--nmap`: print help aobut nmap-compatibility alternatives for these
+  * `--nmap`: print help about nmap-compatibility alternatives for these
     options.
 
   * `--pcap-payloads`: read packets from a libpcap file containing packets


### PR DESCRIPTION
Hi Robert!

A minor typo fixed in `masscan.8` and `masscan.8.markdown` doc.

Please review :-)

Regards
Puru