### PR TITLE
Fix RFC1918 netmask (172.16.0.0/12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ scan all "private" IP addresses. That would be the table of ranges like:
     
     192.168.0.0/16
     10.0.0.0/8
-    172.16.0.0/20
+    172.16.0.0/12
 
 In this example, the first 64k indexes are appended to 192.168.x.x to form
 the target address. Then, the next 16-million are appended to 10.x.x.x.

--- a/doc/masscan.8.markdown
+++ b/doc/masscan.8.markdown
@@ -280,7 +280,7 @@ might be:
 
 	# targets
 	range = 10.0.0.0/8,192.168.0.0/16
-	range = 172.16.0.0/14
+	range = 172.16.0.0/12
 	ports = 20-25,80,U:53
 	ping = true
 


### PR DESCRIPTION
RFC1918 specifies 172.16.0.0/12 (rather than /20 or /14)

https://tools.ietf.org/html/rfc1918
