### PR TITLE
Update main.c

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1053,8 +1053,9 @@ main_scan(struct Masscan *masscan)
         script = script_lookup(masscan->script.name);
         
         /* If no ports specified on command-line, grab default ports */
+        unsigned is_error = 0;
         if (rangelist_count(&masscan->ports) == 0)
-            rangelist_parse_ports(&masscan->ports, script->ports, 0);
+            rangelist_parse_ports(&masscan->ports, script->ports, &is_error);
         
         /* Kludge: change normal port range to script range */
         for (i=0; i<masscan->ports.count; i++) {


### PR DESCRIPTION
Fixing issue #226
There where problems passing the 0 as a valid value on to rangelist_parse_ports
defining is_error = 0 outside the 'if block' and calling the variable seems to do the work, though i am unsure of why.

I have testet build with this fix on windows with Visual Studio 2015 and on CentOS 7 Linux
