### PR TITLE
Update main.c

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1060,6 +1060,7 @@ main_scan(struct Masscan *masscan)
         for (i=0; i<masscan->ports.count; i++) {
             struct Range *r = &masscan->ports.list[i];
             r->begin = (r->begin&0xFFFF) | Templ_Script;
+            r->end = (r->end & 0xFFFF) | Templ_Script;
         }
     }
     


### PR DESCRIPTION
Fixes Issue #225

r->end = (r->end & 0xFFFF) | Templ_Script;

without this line, using --script=ntp-monlist breaks masscan,
