### PR TITLE
[PATCH] BUGFIX: Bracketed the '-p' case handling. Without bracketing, '-p' is currently completely broken

### DIFF
--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -1939,10 +1939,11 @@ masscan_command_line(struct Masscan *masscan, int argc, char *argv[])
             case 'p':
                 if (argv[i][2])
                     arg = argv[i]+2;
-                else
+                else {
                     // arg = argv[++i]; // Passes a NULL value that breaks rangelist_parse_ports in ranges.c
 					fprintf(stderr, "%.*s: empty parameter\n", argv[0], argv[1]);
 					break;
+                }
                 masscan_set_parameter(masscan, "ports", arg);
                 break;
             case 'P':


### PR DESCRIPTION
$ sudo masscan -p 1 1.2.3.4
-p: empty parameter
ERROR: bad IP address/range: 1
FAIL: no ports were specified
 [hint] try something like "-p80,8000-9000"
 [hint] try something like "--ports 0-65535"
$ sudo bin/masscan "-p80,8000-9000" 1.2.3.4
FAIL: no ports were specified
 [hint] try something like "-p80,8000-9000"
 [hint] try something like "--ports 0-65535"
$ sudo bin/masscan -p80,8000-9000 1.2.3.4
FAIL: no ports were specified
 [hint] try something like "-p80,8000-9000"
 [hint] try something like "--ports 0-65535"

This obviously seems wrong. Adding brackets around the 'else' fixes it, though
I still don't understand what the initial change was supposed to do in the
first place?

This doesn't affect anyone who just uses '--ports' or any of the other long
form options, but it seems goofy to leave broken.