### PR TITLE
[PATCH] BUGFIX: The '-iL' option is completely broken when using --ping

### DIFF
--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -1298,6 +1298,8 @@ masscan_set_parameter(struct Masscan *masscan,
         masscan->op = Operation_List_Adapters;
     } else if (EQUALS("includefile", name)) {
         ranges_from_file(&masscan->targets, value);
+        if (masscan->op == 0)
+            masscan->op = Operation_Scan;
     } else if (EQUALS("infinite", name)) {
         masscan->is_infinite = 1;
     } else if (EQUALS("interactive", name)) {


### PR DESCRIPTION
This fixes -iL <file> to behave as expected and perform a ping scan
of the ranges in the file. Before it seemed to think there was
not scan activity to perform.

masscan -iL <file> --ping 

With this small patch, this now works, in master it fails.This is because it failed to set a flag that told masscan that it should do something (move on to the scanning stage) after parsing the commandline arguments.
