### PR TITLE
[PATCH] FEATURE: Deduplicate ICMP like SYN/ACK and increase deduplication bucket size

### DIFF
--- a/src/main-dedup.c
+++ b/src/main-dedup.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define DEDUP_ENTRIES 4096
+#define DEDUP_ENTRIES 65536 /* more aggressive deduplication */
 
 struct DedupEntry
 {

--- a/src/proto-icmp.c
+++ b/src/proto-icmp.c
@@ -5,6 +5,7 @@
 #include "output.h"
 #include "masscan-status.h"
 #include "templ-port.h"
+#include "main-dedup.h"
 
 
 /***************************************************************************
@@ -65,6 +66,13 @@ handle_icmp(struct Output *out, time_t timestamp,
     unsigned ip_them;
     unsigned cookie;
 
+    /* dedup ICMP echo replies as well as SYN/ACK replies */
+    static struct DedupTable *echo_reply_dedup = NULL;
+
+
+    if (!echo_reply_dedup)
+        echo_reply_dedup = dedup_create();
+
     ip_me = parsed->ip_dst[0]<<24 | parsed->ip_dst[1]<<16
             | parsed->ip_dst[2]<< 8 | parsed->ip_dst[3]<<0;
     ip_them = parsed->ip_src[0]<<24 | parsed->ip_src[1]<<16
@@ -80,6 +88,9 @@ handle_icmp(struct Output *out, time_t timestamp,
         cookie = (unsigned)syn_cookie(ip_them, Templ_ICMP_echo, ip_me, 0, entropy);
         if ((cookie & 0xFFFFFFFF) != seqno_me)
             return; /* not my response */
+
+        if (dedup_is_duplicate(echo_reply_dedup, ip_them, 0, ip_me, 0))
+            break;
 
         //if (syn_hash(ip_them, Templ_ICMP_echo) != seqno_me)
         //    return; /* not my response */


### PR DESCRIPTION
Implement deduplication for ICMP replies in the same style as SYN/ACK replies. This is not a perfect process and the effectiveness is determined by a bucket size. I've also increased the bucket size from 4k to 64k.

This is useful for performing ping only sweeps with --retry for extra reliability where packet loss might occur.

The bucket size affects the SYN/ACK deduplication as well due to its location in the code and it didn't seem appropriate to split them apart into two different parameters.
