### PR TITLE
[PATCH] BUGFIX: broken '-p' fix wasn't regression tested, broke stuff

### DIFF
--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -1940,9 +1940,13 @@ masscan_command_line(struct Masscan *masscan, int argc, char *argv[])
                 if (argv[i][2])
                     arg = argv[i]+2;
                 else
-                    // arg = argv[++i]; // Passes a NULL value that breaks rangelist_parse_ports in ranges.c
-					fprintf(stderr, "%.*s: empty parameter\n", argv[0], argv[1]);
-					break;
+                    arg = argv[++i]; // Passes a NULL value that breaks rangelist_parse_ports in ranges.c
+				
+                if (!arg){
+                    fprintf(stderr, "%.*s: empty parameter\n", argv[0], argv[1]);
+                    exit(1);
+                }
+
                 masscan_set_parameter(masscan, "ports", arg);
                 break;
             case 'P':


### PR DESCRIPTION
The original patch added a two line else statement but didn't bracket it. I changed the entire fix for style reasons. Feel free to just add brackets to the original fix, but I find this looks cleaner.
