### PR TITLE
[PATCH] BUGFIX to make show = all in config files work correctly

### DIFF
--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -1374,6 +1374,11 @@ masscan_set_parameter(struct Masscan *masscan,
                 masscan->output.is_show_closed = 1;
             else if (EQUALSx("open", val2, val2_len))
                 masscan->output.is_show_host = 1;
+            else if (EQUALSx("all",val2,val2_len)) {
+                masscan->output.is_show_open = 1;
+                masscan->output.is_show_host = 1;
+                masscan->output.is_show_closed = 1;
+            }
             else {
                 LOG(0, "FAIL: unknown 'show' spec: %.*s\n", val2_len, val2);
                 exit(1);


### PR DESCRIPTION
- which means show host up, port open and port closed info. And most important, it means don't throw an en error when show = all is encountered in a config file

things:
- Closed ports
- Open ports
- Up hosts

Note that the following two are equivalent in the config file:

show = open,closed,host
show = all

Without this patch, show = all in a config file threw an error. I believe this is the correct way to fix it, though I wasn't sure if show_open was necessary since it is set by default. I chose to go with setting show_open because if a user did:

...
show = closed
show = all
..

... in a config file, the resulting behavior should (I think) be show = all, so show_open would have to be restored to its default value.

Pointed out by blkshv:
https://github.com/robertdavidgraham/masscan/issues/190

Also:
Gentoo bug @ https://bugs.gentoo.org/show_bug.cgi?id=503400
