### PR TITLE
Sort list of source files for deterministic linking order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ tmp/%.o: src/%.c src/*.h
 	$(CC) $(CFLAGS) -c $< -o $@
 
 
-SRC = $(wildcard src/*.c)
+SRC = $(sort $(wildcard src/*.c))
 OBJ = $(addprefix tmp/, $(notdir $(addsuffix .o, $(basename $(SRC))))) 
 
 


### PR DESCRIPTION
The order of object files is derived from the list of source files,
which has no deterministic order.
Sort the list to enable reproducible building.