### PR TITLE
fix openwrt compile error

### DIFF
--- a/src/pixie-backtrace.c
+++ b/src/pixie-backtrace.c
@@ -11,7 +11,7 @@
 char global_self[512] = "";
 
 
-#if defined(__linux__)
+#if defined(__linux__) && defined(__GLIBC__)
 #include <unistd.h>
 #include <execinfo.h>
 #include <dlfcn.h>

--- a/src/pixie-backtrace.c
+++ b/src/pixie-backtrace.c
@@ -11,7 +11,7 @@
 char global_self[512] = "";
 
 
-#if defined(__linux__) && defined(__GLIBC__)
+#if defined(__linux__) && !defined(__UCLIBC__)
 #include <unistd.h>
 #include <execinfo.h>
 #include <dlfcn.h>

--- a/src/pixie-backtrace.c
+++ b/src/pixie-backtrace.c
@@ -11,7 +11,7 @@
 char global_self[512] = "";
 
 
-#if defined(__linux__) && !defined(__UCLIBC__)
+#if defined(__GLIBC__)
 #include <unistd.h>
 #include <execinfo.h>
 #include <dlfcn.h>


### PR DESCRIPTION
when compiled in openwrt sdk environment, will find no find execinfo.h error