### PR TITLE
fix clang build error on FreeBSD 12

### DIFF
--- a/src/smack1.c
+++ b/src/smack1.c
@@ -115,6 +115,8 @@
 #include "pixie-timer.h"
 #if defined(_MSC_VER)
 #include <intrin.h>
+#elif defined(__llvm__)
+#include <x86intrin.h>
 #elif defined(__GNUC__)
 static __inline__ unsigned long long __rdtsc(void)
 {


### PR DESCRIPTION
Release 1.0.4 has a followed build error on FreeBSD 12-CURRENT:

src/smack1.c:119:38: error: definition of builtin function '__rdtsc'
static __inline__ unsigned long long __rdtsc(void)
                                     ^
1 error generated.

So, I make a patch to fix this issue.
I tested this code with clang on FreeBSD 10.3,11.0,12.0 and OS X El Capitan

Mac OS X El Capitan
masscan $ make regress
bin/masscan --selftest
regression test: success!
masscan $ uname -a
Darwin 15.6.0 Darwin Kernel Version 15.6.0: Tue Apr 11 16:00:51 PDT 2017; root:xnu-3248.60.11.5.3~1/RELEASE_X86_64 x86_64
masscan $ clang -v
Apple LLVM version 8.0.0 (clang-800.0.38)
Target: x86_64-apple-darwin15.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

FreeBSD 12
root@test-ports:/usr/ports/security/masscan # make regression-test
/usr/ports/security/masscan/work/masscan-1.0.4/bin/masscan --selftest
regression test: success!
root@test-ports:/usr/ports/security/masscan # uname -a
FreeBSD test-ports 12.0-CURRENT FreeBSD 12.0-CURRENT #0 r319481: Fri Jun  2 01:31:26 UTC 2017     root@releng3.nyi.freebsd.org:/usr/obj/usr/src/sys/GENERIC  amd64
root@test-ports:/usr/ports/security/masscan # clang -v
FreeBSD clang version 4.0.0 (tags/RELEASE_400/final 297347) (based on LLVM 4.0.0)
Target: x86_64-unknown-freebsd12.0
Thread model: posix
InstalledDir: /usr/bin

11.0 and 10.3 are also OK to install from the latest FreeBSD ports tree.
Note: If you want to build HEAD on FreeBSD 10.3, you should upgrade clang to 3.5+ manually.

How to install release version masscan from using ports tree on FreeBSD:
At first, get or update the latest ports tree.
`# cd /usr/ports/security/masscan`
`# make install clean`