### PR TITLE
[PATCH] FEATURE: File based POSIX locking (to prevent multiple instances from melting a LAN) #238

### DIFF
--- a/src/masscan.h
+++ b/src/masscan.h
@@ -348,6 +348,9 @@ struct Masscan
     unsigned char *http_user_agent;
     unsigned http_user_agent_length;
     unsigned tcp_connection_timeout;
+#if defined(__linux__)
+    unsigned char *lockfile;
+#endif
     
     /** Number of seconds to wait for a 'hello' from the server before
      * giving up and sending a 'hello' from the client. Should be a small

--- a/src/pixie-backtrace.c
+++ b/src/pixie-backtrace.c
@@ -11,7 +11,7 @@
 char global_self[512] = "";
 
 
-#if defined(__GLIBC__) && !defined(WIN32)
+#if defined(__GLIBC__)
 #include <unistd.h>
 #include <execinfo.h>
 #include <dlfcn.h>
@@ -89,6 +89,7 @@ pixie_backtrace_init(const char *self)
 	signal(SIGSEGV, handle_segfault);
 }
 #elif defined(__MINGW32__)
+#include <bfd.h>
 
 void
 pixie_backtrace_init(const char *self)

--- a/src/pixie-backtrace.c
+++ b/src/pixie-backtrace.c
@@ -11,7 +11,7 @@
 char global_self[512] = "";
 
 
-#if defined(__GLIBC__)
+#if defined(__GLIBC__) && !defined(WIN32)
 #include <unistd.h>
 #include <execinfo.h>
 #include <dlfcn.h>
@@ -89,7 +89,6 @@ pixie_backtrace_init(const char *self)
 	signal(SIGSEGV, handle_segfault);
 }
 #elif defined(__MINGW32__)
-#include <bfd.h>
 
 void
 pixie_backtrace_init(const char *self)

--- a/src/posix-lock.c
+++ b/src/posix-lock.c
@@ -1,0 +1,78 @@
+#if defined(__linux__)
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include <string.h>
+#include "posix-lock.h"
+#include "logger.h"
+
+/* 
+  Lock a file or die, to provide assurance that a 'scan manager' won't 
+  melt your LAN
+
+  Here, 'scan manager' means some automated script or application that 
+  invokes masscan infinitely in a serial fashion, rather than using the
+  masscan infinite flag. 
+
+  This feature is designed to prevent a buggy or broken scan manager from 
+  invoking the same masscan instance more than once. This can happen if it 
+  fails (i.e. crashes) and doesn't clean up the child masscan process, and
+  doesn't go through all the trouble of checking the process list to try
+  and find the process. Relying on a PID file isn't always reliable when
+  things crash.
+
+  Yes, fix the scan manager so that it doesn't crash, or makes sure its
+  children are cleaned up somehow, but for networks that can't handle certain 
+  packet rates, this is a failsafe to prevent the possibility of affecting 
+  production networks/systems that can't handle multiple scans at once. 
+  This is really only a concern on a LAN, I think.
+
+  Because the purpose of this feature is to prevent mistakes, O_CREAT is not 
+  used. If the lock file doesn't already exist, it's possible the scan manager
+  is broken and trying to run wild. It is up to the scan manager to manage the
+  creation and deletion of the lock file and not the responsibility of masscan.
+
+  Exit if the lock file couldn't be opened
+  Exit if the fctnl(F_SETLK) failed
+
+  Return 0 if the lock was successful, application should continue
+
+  There is no unlock, we just let the lock die at process termination for 
+  simplicity. Note this short-circuits command line parsing.
+*/
+
+int
+acquire_posix_lock (const char *filename)
+{
+  struct flock fl = { F_WRLCK, SEEK_SET, 0, 0, 0 };
+  int fd;
+  int result = 0;
+
+  fl.l_pid = getpid ();
+
+  if ((fd = open (filename, O_RDWR)) == -1)
+    {
+      LOG(0,"FAIL: lock file can't be opened with errno message %s\n",strerror(errno));
+      exit(1);
+    }
+
+  if ((result = fcntl (fd, F_SETLK, &fl)) == -1)
+    {
+      if (errno == EAGAIN)
+	     {
+	       LOG (0, "FAIL: lock file %s is already locked by another process\n",filename);
+	     }
+      else
+	     { /* I don't know why this would ever happen unless some other application is messing with our lock */
+	       LOG (0, "FAIL: failed to acquire lock on file %s with errno message %s\n", filename,
+	       strerror (errno));
+	     }
+      exit(1);
+    }
+
+  return result;
+}
+#endif

--- a/src/posix-lock.h
+++ b/src/posix-lock.h
@@ -1,0 +1,8 @@
+#ifndef POSIX_LOCK_H
+#define POSIX_LOCK_H
+
+#if defined(__linux__) && defined(__GNUC__)
+int acquire_posix_lock (const char *filename);
+#endif
+
+#endif


### PR DESCRIPTION
This is a simple feature for Linux that allows a user (most likely an automated script) to specify a lock file to prevent masscan from being invoked twice. This is meant to prevent a programmatic use of masscan from melting the LAN (or from exhausting your bandwidth on a WAN, if you have an unmetered connection that is billed based on usage and are using zero-copy)

```
$ masscan \
  --adapter eth0:zc \
  --adapter-ip 1.2.3.4 \
  --router-ip 1.2.3.1 \
  --adapter-mac aa:bb:cc:dd:ee:ff \
  --adapter-port 60000 \
  --rate 1000000 \
  --lockfile /tmp/autoscan_v1
```