### PR TITLE
[PATCH][BUGFIX] fix json output to produce valid json, current json output has a trailing comma

### DIFF
--- a/src/out-json.c
+++ b/src/out-json.c
@@ -4,6 +4,13 @@
 #include "string_s.h"
 #include <ctype.h>
 
+/* Used to keep state to know when to not place a comma */
+static int json_stream_started = 0;
+
+#define SEPARATE_ENTRIES()     if (json_stream_started) \
+        fprintf(fp, ",\n"); \
+    else \
+        json_stream_started = 1
 
 /****************************************************************************
  ****************************************************************************/
@@ -21,7 +28,7 @@ static void
 json_out_close(struct Output *out, FILE *fp)
 {
     UNUSEDPARM(out);
-    fprintf(fp, "]\n"); // enclose the atomic {}'s into an []
+    fprintf(fp, "\n]\n"); // enclose the atomic {}'s into an []
 }
 
 //{ ip: "124.53.139.201", ports: [ {port: 443, proto: "tcp", status: "open", reason: "syn-ack", ttl: 48} ] }
@@ -35,6 +42,8 @@ json_out_status(struct Output *out, FILE *fp, time_t timestamp, int status,
     UNUSEDPARM(out);
     //UNUSEDPARM(timestamp);
 
+    SEPARATE_ENTRIES();
+
     fprintf(fp, "{ ");
     fprintf(fp, "  \"ip\": \"%u.%u.%u.%u\", ",
             (ip>>24)&0xFF, (ip>>16)&0xFF, (ip>> 8)&0xFF, (ip>> 0)&0xFF);
@@ -47,7 +56,7 @@ json_out_status(struct Output *out, FILE *fp, time_t timestamp, int status,
                 reason_string(reason, reason_buffer, sizeof(reason_buffer)),
                 ttl
             );
-    fprintf(fp, "},\n");
+    fprintf(fp, "}");
 
 
 }
@@ -101,6 +110,8 @@ json_out_banner(struct Output *out, FILE *fp, time_t timestamp,
     UNUSEDPARM(ttl);
     //UNUSEDPARM(timestamp);
 
+    SEPARATE_ENTRIES();
+
     fprintf(fp, "{ ");
     fprintf(fp, "  \"ip\": \"%u.%u.%u.%u\", ",
             (ip>>24)&0xFF, (ip>>16)&0xFF, (ip>> 8)&0xFF, (ip>> 0)&0xFF);
@@ -111,7 +122,7 @@ json_out_banner(struct Output *out, FILE *fp, time_t timestamp,
             masscan_app_to_string(proto),
             normalize_json_string(px, length, banner_buffer, sizeof(banner_buffer))
             );
-    fprintf(fp, "},\n");
+    fprintf(fp, "}");
 
     UNUSEDPARM(out);
 

--- a/src/out-json.c
+++ b/src/out-json.c
@@ -7,6 +7,7 @@
 /* Used to keep state to know when to not place a comma */
 static int json_stream_started = 0;
 
+/* Ugly macro, required in json_out_{status,banner} */
 #define SEPARATE_ENTRIES()     if (json_stream_started) \
         fprintf(fp, ",\n"); \
     else \
@@ -39,9 +40,8 @@ json_out_status(struct Output *out, FILE *fp, time_t timestamp, int status,
                unsigned ip, unsigned ip_proto, unsigned port, unsigned reason, unsigned ttl)
 {
     char reason_buffer[128];
-    UNUSEDPARM(out);
-    //UNUSEDPARM(timestamp);
 
+    UNUSEDPARM(out);
     SEPARATE_ENTRIES();
 
     fprintf(fp, "{ ");
@@ -108,8 +108,6 @@ json_out_banner(struct Output *out, FILE *fp, time_t timestamp,
     char banner_buffer[65536];
 
     UNUSEDPARM(ttl);
-    //UNUSEDPARM(timestamp);
-
     SEPARATE_ENTRIES();
 
     fprintf(fp, "{ ");
@@ -125,28 +123,6 @@ json_out_banner(struct Output *out, FILE *fp, time_t timestamp,
     fprintf(fp, "}");
 
     UNUSEDPARM(out);
-
-/*    fprintf(fp, "<host endtime=\"%u\">"
-            "<address addr=\"%u.%u.%u.%u\" addrtype=\"ipv4\"/>"
-            "<ports>"
-            "<port protocol=\"%s\" portid=\"%u\">"
-            "<state state=\"open\" reason=\"%s\" reason_ttl=\"%u\" />"
-            "<service name=\"%s\" banner=\"%s\"></service>"
-            "</port>"
-            "</ports>"
-            "</host>"
-            "\r\n",
-            (unsigned)timestamp,
-            (ip>>24)&0xFF,
-            (ip>>16)&0xFF,
-            (ip>> 8)&0xFF,
-            (ip>> 0)&0xFF,
-            name_from_ip_proto(ip_proto),
-            port,
-            reason, ttl,
-            masscan_app_to_string(proto),
-            normalize_string(px, length, banner_buffer, sizeof(banner_buffer))
-            );*/
 }
 
 /****************************************************************************


### PR DESCRIPTION
Without this patch, the JSON output is invalid and looks like this:

```
[
{   "ip": "1.2.3.4",   "timestamp": "1501607463", "ports": [ {"port": 22, "proto": "tcp", "status": "open", "reason": "syn-ack", "ttl": 128} ] },
{   "ip": "1.2.3.4",   "timestamp": "1501607463", "ports": [ {"port": 22, "proto": "tcp", "service": {"name": "ssh", "banner": "SSH-2.0-OpenSSH_6.6.1"} } ] }, 
]
```

Note the trailing comma in the list. This breaks JSON parsers. The patch adds the comma to the beginning of a new entry and checks a simple state variable to know not to emit a comma on the first entry. There's code reuse so it's kind of an ugly macro. I'm happy to rework it however you prefer.

I also removed some dead code that was commented out