### PR TITLE
Fix make: clang: Command not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This tool is free, but consider funding it here:
 
 On Debian/Ubuntu, it goes something like this:
 
-	$ sudo apt-get install git gcc make libpcap-dev
+	$ sudo apt-get install git gcc make libpcap-dev clang
 	$ git clone https://github.com/robertdavidgraham/masscan
 	$ cd masscan
 	$ make


### PR DESCRIPTION
Add clang in install. Fix "make: clang: Command not found" if call "make" on ubuntu 16.04