### PR TITLE
fix dns banner corruption from invalid txtlen

### DIFF
--- a/src/proto-dns.c
+++ b/src/proto-dns.c
@@ -399,12 +399,14 @@ handle_dns(struct Output *out, time_t timestamp,
         unsigned rrlen = px[offset+8]<<8 | px[offset+9];
         unsigned txtlen = px[offset+10];
 
+        offset += 11;
+
+        if (txtlen + offset > length)
+            txtlen = length - offset;
         if (rrlen == 0 || txtlen > rrlen-1)
             return 0;
         if (type != 0x10 || xclass != 3)
             return 0;
-
-        offset += 11;
 
         output_report_banner(
                 out, timestamp,


### PR DESCRIPTION
### The problem
The value ```txtlen``` is used to decide how many bytes of ```px+offset``` are
to be read into the banner buffer. The ```txtlen``` value is taken from the DNS
response without validation. 

### No security problems
A malicious server setting the ```txtlen``` to the max possible value (0xff)
would still not be able to overflow the banner buffer. 

At worst, a malicious DNS server would set ```txtlen``` to 0xff and provide an
empty banner. As a result the 0xff bytes of memory after ```px``` would be
saved as the DNS banner. This leaks memory but only to the person running the
scan.

### The fix
A check was added to reduce ```txtlen``` if it is too large. Alternatively a
```return 0;``` could be used. 

I moved the line ```offset += 11;``` up to keep the validation checks together
and avoid adding 11 to the ```txtlen``` check.