### PR TITLE
clang needs to be added or error (Debain x64 issue maybe?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This tool is free, but consider funding it here:
 
 On Debian/Ubuntu, it goes something like this:
 
-	$ sudo apt-get install git gcc make libpcap-dev
+	$ sudo apt-get install git gcc make libpcap-dev clang
 	$ git clone https://github.com/robertdavidgraham/masscan
 	$ cd masscan
 	$ make


### PR DESCRIPTION
Added "clang" into "apt-get" without this will bring this following error on Debain based systems (Ubuntu Debain etc)

clang -g -ggdb    -Wall -O3 -c src/crypto-base64.c -o tmp/crypto-base64.o
make: clang: Command not found
Makefile:87: recipe for target 'tmp/crypto-base64.o' failed
make: *** [tmp/crypto-base64.o] Error 127]

http://apt.llvm.org