### PR TITLE
Allows for compilation in newer versions of Visual Studio

### DIFF
--- a/src/string_s.h
+++ b/src/string_s.h
@@ -55,7 +55,7 @@
 
 const char *strerror_x(int x);
 
-#if defined(_MSC_VER) && (_MSC_VER == 1900)
+#if defined(_MSC_VER) && (_MSC_VER >= 1900)
 /*Visual Studio 2015*/
 # include <stdio.h>
 # include <string.h>


### PR DESCRIPTION
I haven't tested this through but this allows the compilation of masscan in Visual Studio 2017 under Windows 10, because it allows newer versions of VC++ than 2015 (like 2017).

For more information check https://blogs.msdn.microsoft.com/vcblog/2016/10/05/visual-c-compiler-version/