### PR TITLE
Fixing the TCP packet length to include MSS options.

### DIFF
--- a/src/templ-pkt.c
+++ b/src/templ-pkt.c
@@ -29,7 +29,7 @@ static unsigned char default_tcp_template[] =
     "\x08\x00"      /* Ethernet type: IPv4 */
     "\x45"          /* IP type */
     "\x00"
-    "\x00\x28"      /* total length = 40 bytes */
+    "\x00\x2c"      /* total length = 44 bytes  -- needs to be changed if options are added! */
     "\x00\x00"      /* identification */
     "\x00\x00"      /* fragmentation flags */
     "\xFF\x06"      /* TTL=255, proto=TCP */
@@ -41,7 +41,7 @@ static unsigned char default_tcp_template[] =
     "\0\0"          /* destination port */
     "\0\0\0\0"      /* sequence number */
     "\0\0\0\0"      /* ack number */
-    "\x50"          /* header length */
+    "\x60"          /* header length -- needs to be changed if options are added! */
     "\x02"          /* SYN */
     "\x04\x0"        /* window fixed to 1024 */
     "\xFF\xFF"      /* checksum */


### PR DESCRIPTION
In 2014 the MSS options were added to the TCP template packet without adjusting the IP- and TCP-length fields. Due to this oversight, the MSS options were never sent.