### PR TITLE
Add missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This tool is free, but consider funding it here:
 
 On Debian/Ubuntu, it goes something like this:
 
-	$ sudo apt-get install git gcc make libpcap-dev
+	$ sudo apt-get install git gcc make libpcap-dev clang
 	$ git clone https://github.com/robertdavidgraham/masscan
 	$ cd masscan
 	$ make


### PR DESCRIPTION
clang is required but was not defined here. This resulted builds to fails, as in my case (Debian Stretch).

**Distributor ID:**	Debian
**Description:**	Debian GNU/Linux 9.3 (stretch)
**Release:**	9.3
**Codename:**	stretch

```
xzero@ASPIRE-NITRO:~/masscan (master)$ make
clang -g -ggdb    -Wall -O3 -c src/crypto-base64.c -o tmp/crypto-base64.o
make: clang: Command not found
Makefile:87: recipe for target 'tmp/crypto-base64.o' failed
make: *** [tmp/crypto-base64.o] Error 127
```