### PR TITLE
Support send packet on SLL using native linux sendto 

### DIFF
--- a/src/proto-preprocess.c
+++ b/src/proto-preprocess.c
@@ -456,6 +456,10 @@ parse_linux_sll:
      +--------+--------+
      */
     {
+/*
+ * sll is not used, so we don't lost time to decode it, take only ethertype
+ */
+#if 0
         struct {
             unsigned packet_type;
             unsigned arp_type;
@@ -463,17 +467,19 @@ parse_linux_sll:
             unsigned char mac_address[8];
             unsigned ethertype;
         } sll;
-        
+#endif
         VERIFY_REMAINING(16, FOUND_SLL);
-        
+#if 0
         sll.packet_type = ex16be(px+offset+0);
         sll.arp_type = ex16be(px+offset+2);
         sll.addr_length = ex16be(px+offset+4);
         memcpy(sll.mac_address, px+offset+6, 8);
         sll.ethertype = ex16be(px+offset+14);
-   
+#endif
+        ethertype = ex16be(px+offset+14);
+
         offset += 16;
-        
+
         goto parse_ethertype;
     }
     

--- a/src/rawsock-adapter.h
+++ b/src/rawsock-adapter.h
@@ -8,9 +8,14 @@ struct Adapter
     struct __pfring *ring;
     unsigned is_packet_trace:1; /* is --packet-trace option set? */
     unsigned is_vlan:1;
+    unsigned is_iplayer:1;
     unsigned vlan_id;
     double pt_start;
     int link_type;
+#if defined(__linux__)
+    int socket_send;
+    struct sockaddr_ll sll_struct;
+#endif
 };
 
 #endif

--- a/src/rawsock-arp.c
+++ b/src/rawsock-arp.c
@@ -19,6 +19,10 @@
 #include "pixie-timer.h"
 #include "packet-queue.h"
 
+#if defined(__linux__)
+#include <netpacket/packet.h>
+#endif
+
 #define VERIFY_REMAINING(n) if (offset+(n) > max) return;
 
 struct ARP_IncomingRequest
@@ -107,7 +111,7 @@ arp_resolve_sync(struct Adapter *adapter,
      *  ARPing, just return immediately. In other words, there's nothing
      *  here to ARP
      */
-    if (rawsock_datalink(adapter) == 12) {
+    if (adapter->is_iplayer) {
         memcpy(your_mac_address, "\0\0\0\0\0\2", 6);
         return 0; /* success */
     }

--- a/src/templ-pkt.c
+++ b/src/templ-pkt.c
@@ -898,7 +898,7 @@ _template_init(
      * the correct way to do this, but I'm too lazy to refactor code
      * for the right way, so we'll do it this way now.
      */
-    if (data_link == 12 /* Raw IP */) {
+    if (data_link == 12 /* Raw IP */ || data_link == 113 /* SLL Socket Cooked mode */ ) {
         tmpl->length -= tmpl->offset_ip;
         tmpl->offset_tcp -= tmpl->offset_ip;
         tmpl->offset_app -= tmpl->offset_ip;


### PR DESCRIPTION
With this commit, I fixed a bug on receive packet, in SLL code ethertype is not set so nothing is working when receive a packet on interface SLL.
Now on linux masscan send packet without use pcap, so we can support socket SLL.
I have tested on VPS OpenVZ and is working.
