### PR TITLE
Support For Visual Studio 2012, 2013 and all 2017 versions to date

### DIFF
--- a/src/string_s.h
+++ b/src/string_s.h
@@ -55,8 +55,44 @@
 
 const char *strerror_x(int x);
 
-#if defined(_MSC_VER) && (_MSC_VER == 1900)
+#if defined(_MSC_VER) && (_MSC_VER >= 1910) && (_MSC_VER <= 1915)
+/*Visual Studio 2017 (v15.0-15.8)*/
+# include <stdio.h>
+# include <string.h>
+# define strcasecmp     _stricmp
+# define memcasecmp     _memicmp
+# ifndef PRIu64
+#  define PRIu64 "llu"
+#  define PRId64 "lld"
+#  define PRIx64 "llx"
+# endif
+
+#elif defined(_MSC_VER) && (_MSC_VER == 1900)
 /*Visual Studio 2015*/
+# include <stdio.h>
+# include <string.h>
+# define strcasecmp     _stricmp
+# define memcasecmp     _memicmp
+# ifndef PRIu64
+#  define PRIu64 "llu"
+#  define PRId64 "lld"
+#  define PRIx64 "llx"
+# endif
+
+#elif defined(_MSC_VER) && (_MSC_VER == 1800)
+/*Visual Studio 2013*/
+# include <stdio.h>
+# include <string.h>
+# define strcasecmp     _stricmp
+# define memcasecmp     _memicmp
+# ifndef PRIu64
+#  define PRIu64 "llu"
+#  define PRId64 "lld"
+#  define PRIx64 "llx"
+# endif
+
+#elif defined(_MSC_VER) && (_MSC_VER == 1700)
+/*Visual Studio 2012*/
 # include <stdio.h>
 # include <string.h>
 # define strcasecmp     _stricmp
@@ -78,7 +114,6 @@ const char *strerror_x(int x);
 #  define PRId64 "lld"
 #  define PRIx64 "llx"
 # endif
-
 
 #elif defined(_MSC_VER) && (_MSC_VER == 1200)
 /* Visual Studio 6.0 */


### PR DESCRIPTION
Adding support for VS2012 (MSVC++ 11), 2013 (MSVC++ 12), and all 2017 (MSVC++ 14.1x) versions as of this pull request.