### PR TITLE
fix error: conflicting types for 'clock_gettime'

### DIFF
--- a/src/pixie-timer.c
+++ b/src/pixie-timer.c
@@ -47,7 +47,7 @@ getFILETIMEoffset(void)
 }
 
 int
-clock_gettime(int X, struct timeval *tv)
+_clock_gettime(int X, struct timeval *tv)
 {
     LARGE_INTEGER           t;
     FILETIME            f;
@@ -92,7 +92,7 @@ uint64_t
 pixie_gettime(void)
 {
     //struct timeval tv;
-    //clock_gettime(0, &tv);
+    //_clock_gettime(0, &tv);
 
     uint64_t time1 = 0, freq = 0;
     double seconds;
@@ -182,12 +182,12 @@ pixie_gettime(void)
     struct timespec tv;
 
 #ifdef CLOCK_MONOTONIC_RAW
-    x = clock_gettime(CLOCK_MONOTONIC_RAW, &tv);
+    x = _clock_gettime(CLOCK_MONOTONIC_RAW, &tv);
 #else
-    x = clock_gettime(CLOCK_MONOTONIC, &tv);
+    x = _clock_gettime(CLOCK_MONOTONIC, &tv);
 #endif
     if (x != 0) {
-        printf("clock_gettime() err %d\n", errno);
+        printf("_clock_gettime() err %d\n", errno);
     }
 
     return tv.tv_sec * 1000000 + tv.tv_nsec/1000;
@@ -199,12 +199,12 @@ pixie_nanotime(void)
     struct timespec tv;
 
 #ifdef CLOCK_MONOTONIC_RAW
-    x = clock_gettime(CLOCK_MONOTONIC_RAW, &tv);
+    x = _clock_gettime(CLOCK_MONOTONIC_RAW, &tv);
 #else
-    x = clock_gettime(CLOCK_MONOTONIC, &tv);
+    x = _clock_gettime(CLOCK_MONOTONIC, &tv);
 #endif
     if (x != 0) {
-        printf("clock_gettime() err %d\n", errno);
+        printf("_clock_gettime() err %d\n", errno);
     }
 
     return tv.tv_sec * 1000000000 + tv.tv_nsec;


### PR DESCRIPTION
This commit fix: error: conflicting types for 'clock_gettime'
when build on MinGW32 (windows)

```
gcc -g -ggdb -march=i686 -Ivs10/include  -Wall -O3 -c src/pixie-timer.c -o tmp/pixie-timer.o
src/pixie-timer.c:50:1: error: conflicting types for 'clock_gettime'
 clock_gettime(int X, struct timeval *tv)
 ^~~~~~~~~~~~~
In file included from D:/msys64/mingw32/i686-w64-mingw32/include/time.h:331:0,
                 from src/pixie-timer.c:19:
```

![image](https://user-images.githubusercontent.com/8877695/53302953-285e5a00-3897-11e9-8aea-36c60b26bb00.png)
