### PR TITLE
add suppot for visual studio 2017

### DIFF
--- a/src/string_s.h
+++ b/src/string_s.h
@@ -55,8 +55,8 @@
 
 const char *strerror_x(int x);
 
-#if defined(_MSC_VER) && (_MSC_VER == 1900)
-/*Visual Studio 2015*/
+#if defined(_MSC_VER) && (_MSC_VER >= 1900)
+/*Visual Studio 2015 and 2017*/
 # include <stdio.h>
 # include <string.h>
 # define strcasecmp     _stricmp


### PR DESCRIPTION
MSVC++ 14.15 _MSC_VER == 1915 (Visual Studio 2017 version 15.8)
MSVC++ 14.14 _MSC_VER == 1914 (Visual Studio 2017 version 15.7)
MSVC++ 14.13 _MSC_VER == 1913 (Visual Studio 2017 version 15.6)
MSVC++ 14.12 _MSC_VER == 1912 (Visual Studio 2017 version 15.5)
MSVC++ 14.11 _MSC_VER == 1911 (Visual Studio 2017 version 15.3)
MSVC++ 15.0 _MSC_VER == 1910 (Visual Studio 2017)