### PR TITLE
Floating-point character conversion error

### DIFF
--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -1366,7 +1366,7 @@ static int SET_rate(struct Masscan *masscan, const char *name, const char *value
                 return CONF_ERR;
             }
             rate += (c - '0')/point;
-            point /= 10.0;
+            point *= 10.0;
             value++;
         }
     }


### PR DESCRIPTION
The parameter of max-rate is double type. We can input command like this.
masscan -p 80,8080 10.0.0.0/8 -oX /home/scan.xml --max-rate 400.12345
I found this decimal calculation wrong.