### PR TITLE
Support nmap-style -p- shorthand

### DIFF
--- a/src/ranges.c
+++ b/src/ranges.c
@@ -909,15 +909,25 @@ rangelist_parse_ports(struct RangeList *ports, const char *string, unsigned *is_
             p += 2;
         }
 
-        if (!isdigit(p[0] & 0xFF))
-            break;
-
-        port = (unsigned)strtoul(p, &p, 0);
-        end = port;
         if (*p == '-') {
             p++;
-            end = (unsigned)strtoul(p, &p, 0);
-        }
+            if (*p == '\0' || *p == ',') {
+                port = 1;
+                end = (proto_offset == Templ_Oproto_first) ? 0xFF : 0xFFFF;
+            } else {
+                LOG(0, "bad port spec: %s\n", string);
+                *is_error = 2;
+                return p;
+            }
+        } else if (isdigit(*p)) {
+            port = (unsigned)strtoul(p, &p, 0);
+            end = port;
+            if (*p == '-') {
+                p++;
+                end = (unsigned)strtoul(p, &p, 0);
+            }
+        } else
+            break;
 
         if (port > 0xFF && proto_offset == Templ_Oproto_first) {
             LOG(0, "bad ports: %u-%u\n", port, end);


### PR DESCRIPTION
To quote nmap's documentation:

> The beginning and/or end values of a range may be omitted, causing Nmap to use 1 and 65535, respectively. So you can specify -p- to scan ports from 1 through 65535.

This PR makes masscan handle -p- this way. If desired, I can generalize this to handle omissions of either side as well.