### PR TITLE
Grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ from a single machine.
 Its input/output is similar to `nmap`, the most famous port scanner.
 When in doubt, try one of those features.
 
-Internally, it uses asynchronous tranmissions, similar to port scanners
+Internally, it uses asynchronous transmissions, similar to port scanners
 like  `scanrand`, `unicornscan`, and `ZMap`. It's more flexible, allowing
 arbitrary port and address ranges.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is an Internet-scale port scanner. It can scan the entire Internet
 in under 6 minutes, transmitting 10 million packets per second,
 from a single machine.
 
-It's input/output is similar to `nmap`, the most famous port scanner.
+Its input/output is similar to `nmap`, the most famous port scanner.
 When in doubt, try one of those features.
 
 Internally, it uses asynchronous tranmissions, similar to port scanners

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ MODULUS (%). In my current benchmarks, it's taking 40 nanoseconds to
 encrypt the variable.
 
 This architecture allows for lots of cool features. For example, it supports
-"shards". You can setup 5 machines each doing a fifth of the scan, or
+"shards". You can set up 5 machines each doing a fifth of the scan, or
 `range / shard_count`. Shards can be multiple machines, or simply multiple
 network adapters on the same machine, or even (if you want) multiple IP
 source addresses on the same network adapter.

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ to convert them into any other format. There are five supported output formats:
 
 2. binary: This is the masscan builtin format. It produces much smaller files so that
 when I scan the Internet my disk doesn't fill up. They need to be parsed,
-though. The command line option `--readscan` will read binary scan files.
+though. The command-line option `--readscan` will read binary scan files.
 Using `--readscan` with the `-oX` option will produce a XML version of the 
 results file.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ use `--src-port` to configure which source ports masscan uses, then also
 configure the internal firewall (like `pf` or `iptables`) to firewall those ports
 from the rest of the operating system.
 
-This tool is free, but consider contributing money to its developement:
+This tool is free, but consider contributing money to its development:
 Bitcoin wallet address: 1MASSCANaHUiyTtR3bJ2sLGuMw5kDBaj4T
 
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ that range, by looking in the file:
 On the latest version of Kali Linux (2018-August), that range is  32768  to  60999, so
 you should choose ports either below 32768 or 61000 and above.
 
-Setting an `iptables` rule only lasts until the next reboot. You need to lookup how to
+Setting an `iptables` rule only lasts until the next reboot. You need to look up how to
 save the configuration depending upon your distro, such as using `iptables-save` 
 and/or `iptables-persistant`.
 

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ or exclude a lot of sub-ranges. This chops up the desired range into hundreds
 of smaller ranges.
 
 This leads to one of the slowest parts of the code. We transmit 10 million
-packets per second, and have to convert an index variable to an IP address
+packets per second and have to convert an index variable to an IP address
 for each and every probe. We solve this by doing a "binary search" in a small
 amount of memory. At this packet rate, cache efficiencies start to dominate
 over algorithm efficiencies. There are a lot of more efficient techniques in

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ instructions are around 90 clock cycles, or 30 nanoseconds, on x86 CPUs. When
 transmitting at a rate of 10 million packets/second, we have only
 100 nanoseconds per packet. I see no way to optimize this any better. Luckily,
 though, two such operations can be executed simultaneously, so doing two 
-of these as shown above is no more expensive than doing one.
+of these, as shown above, is no more expensive than doing one.
 
 There are actually some easy optimizations for the above performance problems,
 but they all rely upon `i++`, the fact that the index variable increases one

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ without the transmit overhead:
 	$ bin/masscan 0.0.0.0/4 -p80 --rate 100000000 --offline
     
 This second benchmark shows roughly how fast the program would run if it were
-using PF_RING, which has near zero overhead.
+using PF_RING, which has near-zero overhead.
 
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ you should choose ports either below 32768 or 61000 and above.
 
 Setting an `iptables` rule only lasts until the next reboot. You need to look up how to
 save the configuration depending upon your distro, such as using `iptables-save` 
-and/or `iptables-persistant`.
+and/or `iptables-persistent`.
 
 On Mac OS X and BSD, there are similar steps. To find out the ranges to avoid,
 use a command like the following:

--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ interfering with the transmit thread.
 ## Portability
 
 The code runs well on Linux, Windows, and Mac OS X. All the important bits are
-in standard C (C90). It therefore compiles on Visual Studio with Microsoft's
+in standard C (C90). It, therefore, compiles on Visual Studio with Microsoft's
 compiler, the Clang/LLVM compiler on Mac OS X, and GCC on Linux.
 
 Windows and Macs aren't tuned for packet transmit, and get only about 300,000

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ to convert them into any other format. There are five supported output formats:
 2. binary: This is the masscan builtin format. It produces much smaller files so that
 when I scan the Internet my disk doesn't fill up. They need to be parsed,
 though. The command-line option `--readscan` will read binary scan files.
-Using `--readscan` with the `-oX` option will produce a XML version of the 
+Using `--readscan` with the `-oX` option will produce an XML version of the 
 results file.
 
 3. grepable: This is an implementation of the Nmap -oG

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ This also makes things easier when you repeat a scan.
 By default, masscan first loads the configuration file 
 `/etc/masscan/masscan.conf`. Any later configuration parameters override what's
 in this default configuration file. That's where I put my "excludefile" 
-parameter, so that I don't ever forget it. It just works automatically.
+parameter so that I don't ever forget it. It just works automatically.
 
 ## Getting output
 

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ MODULUS (%). In my current benchmarks, it's taking 40 nanoseconds to
 encrypt the variable.
 
 This architecture allows for lots of cool features. For example, it supports
-"shards". You can set up 5 machines each doing a fifth of the scan, or
+"shards". You can set up 5 machines each doing a fifth of the scan or
 `range / shard_count`. Shards can be multiple machines, or simply multiple
 network adapters on the same machine, or even (if you want) multiple IP
 source addresses on the same network adapter.

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ to convert them into any other format. There are five supported output formats:
 1. xml:  Just use the parameter `-oX <filename>`. 
 	Or, use the parameters `--output-format xml` and `--output-filename <filename>`.
 
-2. binary: This is the masscan builtin format. It produces much smaller files, so that
+2. binary: This is the masscan builtin format. It produces much smaller files so that
 when I scan the Internet my disk doesn't fill up. They need to be parsed,
 though. The command line option `--readscan` will read binary scan files.
 Using `--readscan` with the `-oX` option will produce a XML version of the 

--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ Masscan has no "mutex". Modern mutexes (aka. futexes) are mostly user-mode,
 but they have two problems. The first problem is that they cause cache-lines
 to bounce quickly back-and-forth between CPUs. The second is that when there
 is contention, they'll do a system call into the kernel, which kills
-performance. Mutexes on the fast path of a program severely limits scalability.
+performance. Mutexes on the fast path of a program severely limit scalability.
 Instead, Masscan uses "rings" to synchronize things, such as when the
 user-mode TCP stack in the receive thread needs to transmit a packet without
 interfering with the transmit thread.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Internally, it uses asynchronous transmissions, similar to port scanners
 like  `scanrand`, `unicornscan`, and `ZMap`. It's more flexible, allowing
 arbitrary port and address ranges.
 
-NOTE: masscan uses a its own **custom TCP/IP stack**. Anything other than
+NOTE: masscan uses its own **custom TCP/IP stack**. Anything other than
 simple port scans may cause conflict with the local TCP/IP stack. This means you 
 need to either the `--src-ip` option to run from a different IP address, or
 use `--src-port` to configure which source ports masscan uses, then also

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ port in order to grab simple "banner" information.
 
 The problem with this is that masscan contains its own TCP/IP stack
 separate from the system you run it on. When the local system receives
-a SYN-ACK from the probed target, it responds with a RST packet that kills
+a SYN-ACK from the probed target, it responds with an RST packet that kills
 the connection before masscan can grab the banner.
 
 The easiest way to prevent this is to assign masscan a separate IP

--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ with the following command:
 
 Windows doesn't respond with RST packets, so neither of these techniques
 are necessary. However, masscan is still designed to work best using its
-own IP address, so you should run that way when possible, even when its
-not strictly necessary.
+own IP address, so you should run that way when possible, even when it
+isn't strictly necessary.
 
 The same thing is needed for other checks, such as the `--heartbleed` check,
 which is just a form of banner checking.

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ heck out of target networks that aren't built for this level of speed. We
 need to spread our traffic evenly over the target.
 
 The way we randomize is simply by encrypting the index variable. By definition,
-encryption is random, and creates a 1-to-1 mapping between the original index
+encryption is random and creates a 1-to-1 mapping between the original index
 variable and the output. This means that while we linearly go through the
 range, the output IP addresses are completely random. In code, this looks like:
 


### PR DESCRIPTION
btw, the repo description:
> TCP port scanner, spews SYN packets asynchronously, scanning entire Internet in under 5 minutes.

should be:
> TCP port scanner, spews SYN packets asynchronously, scanning the entire Internet in under 5 minutes.
