### PR TITLE
Fix function name in stub-pcap

### DIFF
--- a/src/stub-pcap.c
+++ b/src/stub-pcap.c
@@ -244,7 +244,7 @@ static int null_PCAP_SETDIRECTION(pcap_t *p, pcap_direction_t d)
 static const char *null_PCAP_DATALINK_VAL_TO_NAME(int dlt)
 {
 #ifdef STATICPCAP
-    return pcap_datalink_val_toName(dlt);
+    return pcap_datalink_val_to_name(dlt);
 #endif
 	my_null(1, dlt);
     return 0;


### PR DESCRIPTION
For some reason this function has an incorrect name `pcap_datalink_val_toName` - in `libpcap` it's defined as `pcap_datalink_val_to_name`, and even in masscan itself it's properly referenced:
![image](https://user-images.githubusercontent.com/21169548/72670852-b4e7ad00-3a53-11ea-9e0f-9ee3f179c592.png)

Found this when trying to build masscan with static `libpcap`