### PR TITLE
Improve statistical distribution of partial scan

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1516,7 +1516,9 @@ int main(int argc, char *argv[])
      * Initialize those defaults that aren't zero
      */
     memset(masscan, 0, sizeof(*masscan));
-    masscan->blackrock_rounds = 4;
+    /* 14 rounds seem to give way better statistical distribution than 4 with a 
+    very low impact on scan rate */
+    masscan->blackrock_rounds = 14;
     masscan->output.is_show_open = 1; /* default: show syn-ack, not rst */
     masscan->output.is_status_updates = 1; /* default: show status updates */
     masscan->seed = get_entropy(); /* entropy for randomness */


### PR DESCRIPTION
Suggestion to fix issue #505 (see issue discussion for more details about the round value).
Changing the number of rounds for `blackrock` seems to:
- increase the distribution of scanned IP in a partial scan (*e.g.*, after 10% of the scan)
- have a very low impact on scanning rate.