### PR TITLE
added power support arch ppc64le on yml file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 # integration website that will build and test this project
 # every time something is submitted, and send me email if
 # the test breaks
+arch:
+  - amd64
+  - ppc64le
 language: c
 
 os:


### PR DESCRIPTION
Hi Team,
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.
continuous integration build passed without any failures after adding power arch.please check and close this issue.

