### PR TITLE
Fix for #559- (resume broken for most uses, copy/pasta to fix --nocapture=servername)

### DIFF
--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -1736,6 +1736,7 @@ struct ConfigParameter config_parameters[] = {
     {"json-status",     SET_status_json,        F_BOOL, {"status-json", 0}},
     {"min-packet",      SET_min_packet,         0,      {"min-pkt",0}},
     {"capture",         SET_capture,            0,      {0}},
+    {"nocapture",       SET_capture,            0,      {0}},
     {"SPACE",           SET_space,              0,      {0}},
     {"output-filename", SET_output_filename,    0,      {"output-file",0}},
     {"output-format",   SET_output_format,      0,      {0}},

--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -978,6 +978,8 @@ static int SET_capture(struct Masscan *masscan, const char *name, const char *va
     } else if (EQUALS("nocapture", name)) {
         if (EQUALS("cert", value))
             masscan->is_capture_cert = 0;
+        else if (EQUALS("servername", value))
+            masscan->is_capture_servername = 0;
         else if (EQUALS("html", value))
             masscan->is_capture_html = 0;
         else if (EQUALS("heartbleed", value))


### PR DESCRIPTION
This is for #559 

The cli/conf handling code was significantly cleaned up recently (thanks for all that effort @robertdavidgraham) and that fixed a whole handful of issues. That made a huge improvement and fixed at least 3 other (similar) issues, but it looks like this shook out of it all

Like the other options issues, it's an easy fix to test and review:

1. An entry got left out from the `config_parameters[]` for `nocapture` option. The `capture` and `nocapture` options are both handled by `SET_capture`, so the code was there, the dispatch table was just ignorant. So I added a line for `nocapture` to send it there when it encounters that option
2. Within the `"nocapture"` checking block, the `"servername"` case specifically was missing, though the others were there. I just added that in where it belonged

If I'm remembering correctly, `--[no]capture servername` is a relatively new option, which is probably why nobody has noticed until now


@hatarist can you please confirm this fixes your issue? I was able to reproduce locally and it fixed it for me
