### PR TITLE
handle OpenBSD's bpf_timeval

### DIFF
--- a/src/stub-pcap.h
+++ b/src/stub-pcap.h
@@ -23,6 +23,9 @@
 #if __NetBSD__
 #include <sys/time.h>
 #define pcap_timeval timeval
+#elif __OpenBSD__
+#include <net/bpf.h>
+#define pcap_timeval bpf_timeval
 #else
 struct pcap_timeval {
         long    tv_sec;         /* seconds */


### PR DESCRIPTION
OpenBSD uses bpf_timeval (uint32_t tv_sec and tv_usec), with this changed masscan works on OpenBSD as long as you set gateway ip/mac manually.