### PR TITLE
Fix compilation for Termux

### DIFF
--- a/src/out-tcp-services.c
+++ b/src/out-tcp-services.c
@@ -24,7 +24,7 @@ tcp_service_name(int port)
     if (tcp_services[port])
         return tcp_services[port];
 
-#ifdef __linux__
+#if defined(__linux__) && !defined(__TERMUX__)
     int r;
     struct servent result_buf;
     struct servent *result;
@@ -56,7 +56,7 @@ udp_service_name(int port)
 {
     if (udp_services[port])
         return udp_services[port];
-#ifdef __linux__
+#if defined(__linux__) && !defined(__TERMUX__)
     int r;
     struct servent result_buf;
     struct servent *result;

--- a/src/pixie-threads.c
+++ b/src/pixie-threads.c
@@ -74,7 +74,7 @@ pixie_cpu_set_affinity(unsigned processor)
     if (result == 0) {
         fprintf(stderr, "set_affinity: returned error win32:%u\n", (unsigned)GetLastError());
     }
-#elif defined(__linux__) && defined(__GNUC__)
+#elif defined(__linux__) && defined(__GNUC__) && !defined(__TERMUX__)
     int x;
     pthread_t thread = pthread_self();
     cpu_set_t cpuset;


### PR DESCRIPTION
Termux doesn't seem to have `getservbyport_r` and `pthread_setaffinity_np` so I added checks for the `__TERMUX__`  define.

Compilation output before the patch:
```
/data/data/com.termux/files/usr/bin/ld: tmp/out-tcp-services.o: in function `tcp_service_name':
/data/data/com.termux/files/home/masscan/src/out-tcp-services.c:33: undefined reference to `getservbyport_r'
/data/data/com.termux/files/usr/bin/ld: tmp/out-tcp-services.o: in function `udp_service_name':
/data/data/com.termux/files/home/masscan/src/out-tcp-services.c:65: undefined reference to `getservbyport_r'
/data/data/com.termux/files/usr/bin/ld: tmp/pixie-threads.o: in function `pixie_cpu_set_affinity':
/data/data/com.termux/files/home/masscan/src/pixie-threads.c:86: undefined reference to `pthread_setaffinity_np'
clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [Makefile:112: bin/masscan] Error 1
```

After the patch it works with WiFi - tested scanning both LAN and internet with
```
su
./bin/masscan --ports 1-65535 --rate=1000 --interface wlan0 --router-ip 192.168.88.1 8.8.8.8
 ```