### PR TITLE
Fix hello-timeout argument configuration and ipv6 formatter

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -691,7 +691,7 @@ receive_thread(void *v)
         }
         if (masscan->tcp_hello_timeout) {
             char foo[64];
-            sprintf_s(foo, sizeof(foo), "%u", masscan->tcp_connection_timeout);
+            sprintf_s(foo, sizeof(foo), "%u", masscan->tcp_hello_timeout);
             tcpcon_set_parameter(   tcpcon,
                                  "hello-timeout",
                                  strlen(foo),

--- a/src/massip-addr.c
+++ b/src/massip-addr.c
@@ -45,14 +45,16 @@ _append_ipv6(stream_t *out, const unsigned char *ipv6)
          * of 0 can be removed completely, replaced by an extra colon */
         if (n == 0 && !is_ellision) {
             is_ellision = 1;
-            while (i < 16 && ipv6[i + 2] == 0 && ipv6[i + 3] == 0)
+            while (i < 13 && ipv6[i + 2] == 0 && ipv6[i + 3] == 0)
                 i += 2;
             _append_char(out, ':');
 
             /* test for all-zero address, in which case the output
              * will be "::". */
-            if (i == 14)
+            while (i == 14 && ipv6[i] == 0 && ipv6[i + 1] == 0){
+                i=16;
                 _append_char(out, ':');
+            }
             continue;
         }
 


### PR DESCRIPTION
Looks like a copy paste error for the argument.
Also fixed ipv6 address formatter, it was checking for values outside the address buffer and sometimes missing printing the last : 
Would you be interested in a banner parser for Bitcoin?