### PR TITLE
Fix scan not finished for retries > 0 (#574)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1211,7 +1211,8 @@ main_scan(struct Masscan *masscan)
         LOG(0, " [hint] try something like \"--ports 0-65535\"\n");
         return 1;
     }
-    range = count_ips * count_ports + (uint64_t)(masscan->retries * masscan->max_rate);
+    range = count_ips * count_ports;
+    range += (uint64_t)(masscan->retries * range);
 
     /*
      * If doing an ARP scan, then don't allow port scanning


### PR DESCRIPTION
After this commit 952755771ab8065c052cdf4b6d18041435b2d661 to fix issue #574, the scan will not complete because `min_index` will not get higher than `range` in https://github.com/robertdavidgraham/masscan/blob/master/src/main.c#L1419.