### PR TITLE
Fix FreeBSD aarch64 build issue

### DIFF
--- a/src/smack1.c
+++ b/src/smack1.c
@@ -119,8 +119,7 @@
 #elif defined(__FreeBSD__)
 #include <sys/types.h>
 #include <machine/cpufunc.h>
-#define __rdtsc rdtsc
-#if (__ARM_ARCH >= 6)  // V6 is the earliest arch that has a standard cyclecount
+#if (__ARM_ARCH >= 6 && __ARM_ARCH <= 7)  // V6 is the earliest arch that has a standard cyclecount
 unsigned long long rdtsc(void)
 {
   uint32_t pmccntr;
@@ -138,6 +137,10 @@ unsigned long long rdtsc(void)
   }
   return 0;
 }
+#elif defined(__aarch64__)
+#define __rdtsc() 0
+#else
+#define __rdtsc rdtsc
 #endif
 #elif defined (__llvm__)
 #if defined(i386) || defined(__i386__)


### PR DESCRIPTION
Current masscan has a build issue on FreeBSD aarch64.

Error log is following:
src/smack1.c:130:16: error: unrecognized instruction mnemonic, did you mean: mrs, msr, smc?
  asm volatile("mrc p15, 0, %0, c9, c14, 0" : "=r"(pmuseren));
               ^
<inline asm>:1:2: note: instantiated into assembly here
        mrc p15, 0, x8, c9, c14, 0
        ^
src/smack1.c:132:18: error: unrecognized instruction mnemonic, did you mean: mrs, msr, smc?
    asm volatile("mrc p15, 0, %0, c9, c12, 1" : "=r"(pmcntenset));
                 ^
<inline asm>:1:2: note: instantiated into assembly here
        mrc p15, 0, x8, c9, c12, 1
        ^
src/smack1.c:134:20: error: unrecognized instruction mnemonic, did you mean: mrs, msr, smc?
      asm volatile("mrc p15, 0, %0, c9, c13, 0" : "=r"(pmccntr));
                   ^
<inline asm>:1:2: note: instantiated into assembly here
        mrc p15, 0, x8, c9, c13, 0
        ^
src/smack1.c:130:16: error: unrecognized instruction mnemonic, did you mean: mrs, msr, smc?
  asm volatile("mrc p15, 0, %0, c9, c14, 0" : "=r"(pmuseren));
               ^
<inline asm>:1:2: note: instantiated into assembly here
        mrc p15, 0, x8, c9, c14, 0
        ^
src/smack1.c:132:18: error: unrecognized instruction mnemonic, did you mean: mrs, msr, smc?
    asm volatile("mrc p15, 0, %0, c9, c12, 1" : "=r"(pmcntenset));
                 ^
<inline asm>:1:2: note: instantiated into assembly here
        mrc p15, 0, x8, c9, c12, 1
        ^
src/smack1.c:130:16: error: unrecognized instruction mnemonic, did you mean: mrs, msr, smc?
  asm volatile("mrc p15, 0, %0, c9, c14, 0" : "=r"(pmuseren));
               ^
<inline asm>:1:2: note: instantiated into assembly here
        mrc p15, 0, x8, c9, c14, 0
        ^
src/smack1.c:132:18: error: unrecognized instruction mnemonic, did you mean: mrs, msr, smc?
    asm volatile("mrc p15, 0, %0, c9, c12, 1" : "=r"(pmcntenset));
                 ^
<inline asm>:1:2: note: instantiated into assembly here
        mrc p15, 0, x8, c9, c12, 1
        ^
src/smack1.c:134:20: error: unrecognized instruction mnemonic, did you mean: mrs, msr, smc?
      asm volatile("mrc p15, 0, %0, c9, c13, 0" : "=r"(pmccntr));
                   ^
<inline asm>:1:2: note: instantiated into assembly here
        mrc p15, 0, x8, c9, c13, 0
        ^
src/smack1.c:134:20: error: unrecognized instruction mnemonic, did you mean: mrs, msr, smc?
      asm volatile("mrc p15, 0, %0, c9, c13, 0" : "=r"(pmccntr));
                   ^
<inline asm>:1:2: note: instantiated into assembly here
        mrc p15, 0, x8, c9, c13, 0
        ^
3 warnings and 9 errors generated.
gmake: *** [Makefile:109: tmp/smack1.o] Error 1


These errors are due to the difference in arm assembler between the old and newer versions.
Therefore, the inline assembler can not work on later arm8 and caused the error on aarch64.
So this patch is fixed that issue.

I have tested this modification on aarch64 and amd64.
And both successes.

Test environments & results are following:

*aarch64

`freebsd13-rpi2:~/masscan % gmake test`
`bin/masscan --selftest`
`regression test: success!`
`freebsd13-rpi2:~/masscan % uname -a`
`FreeBSD freebsd13-rpi2 13.0-RELEASE FreeBSD 13.0-RELEASE #0 releng/13.0-n244733-ea31abc261f: Fri Apr  9 06:06:55 UTC 2021     
root@releng1.nyi.freebsd.org:/usr/obj/usr/src/arm64.aarch64/sys/GENERIC  arm64`

*amd64

`freebsd13-amd64:~/masscan % gmake test`
`bin/masscan --selftest`
`regression test: success!`
`freebsd13-amd64:~/masscan % uname -a`
`FreeBSD freebsd13-amd64 13.0-RELEASE FreeBSD 13.0-RELEASE #0 releng/13.0-n244733-ea31abc261f: Fri Apr  9 04:24:09 UTC 2021     
root@releng1.nyi.freebsd.org:/usr/obj/usr/src/amd64.amd64/sys/GENERIC  amd64`