### PR TITLE
Removed a duplicate list entry for ssh2.

### DIFF
--- a/src/masscan-app.c
+++ b/src/masscan-app.c
@@ -65,7 +65,6 @@ masscan_string_to_app(const char *str)
         {"ftp",     PROTO_FTP},
         {"dns-ver", PROTO_DNS_VERSIONBIND},
         {"snmp",    PROTO_SNMP},
-        {"ssh2",    PROTO_SSH2},
         {"nbtstat", PROTO_NBTSTAT},
         {"ssl",     PROTO_SSL3},
         {"smtp",    PROTO_SMTP},


### PR DESCRIPTION
`{"ssh2", PROTO_SSH2}` is listed twice.