### PR TITLE
Update too-short lengths in TCP SYN packet template.

### DIFF
--- a/src/templ-pkt.c
+++ b/src/templ-pkt.c
@@ -31,7 +31,7 @@ static unsigned char default_tcp_template[] =
     "\x08\x00"      /* Ethernet type: IPv4 */
     "\x45"          /* IP type */
     "\x00"
-    "\x00\x28"      /* total length = 40 bytes */
+    "\x00\x2C"      /* total length = 44 bytes */
     "\x00\x00"      /* identification */
     "\x00\x00"      /* fragmentation flags */
     "\xFF\x06"      /* TTL=255, proto=TCP */
@@ -43,7 +43,7 @@ static unsigned char default_tcp_template[] =
     "\0\0"          /* destination port */
     "\0\0\0\0"      /* sequence number */
     "\0\0\0\0"      /* ACK number */
-    "\x50"          /* header length */
+    "\x60"          /* header length */
     "\x02"          /* SYN */
     "\x04\x0"        /* window fixed to 1024 */
     "\xFF\xFF"      /* checksum */


### PR DESCRIPTION
When the TCP SYN packet template was updated in https://github.com/robertdavidgraham/masscan/commit/8042cbe480c90785b155ffd0b8dab87fe462e02e, the IP length and TCP length fields were not updated. This caused `preprocess_frame` to use the pre-options length of the payload, which was then used by `_template_init` to override the passed-in length of the template.

The IP length has 4 bytes added (`0x28 -> 0x2C`). The TCP length also has 4 bytes added, but the length is implicitly multiplied by 4, and only the top nibble is used (`0x5 -> 0x6`).

While not part of this bug, it would also be nice to have the TCP window size increased from 1024 to 65535, since the latter matches Linux + OSX + Zmap, while the former matches Nmap. I have begun finding hosts that drop SYN packets with small window sizes and absent MSS options, which is what caused me to investigate this bug.