### PR TITLE
opt-in flag --tcpmss to add MSS option to SYN packet; remediates (real-world) observed border policy drops

### DIFF
--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -1370,6 +1370,13 @@ static int SET_nobanners(struct Masscan *masscan, const char *name, const char *
     return CONF_OK;
 }
 
+static int SET_tcpmss(struct Masscan *masscan, const char *name, const char *value)
+{
+    UNUSEDPARM(name);
+    masscan->is_tcpmss = parseBoolean(value);
+    return CONF_OK;
+}
+
 static int SET_noreset(struct Masscan *masscan, const char *name, const char *value)
 {
     UNUSEDPARM(name);
@@ -1929,6 +1936,7 @@ struct ConfigParameter config_parameters[] = {
     {"shard",           SET_shard,              0,      {"shards",0}},
     {"banners",         SET_banners,            F_BOOL, {"banner",0}},
     {"nobanners",       SET_nobanners,          F_BOOL, {"nobanner",0}},
+    {"tcpmss",          SET_tcpmss,             F_BOOL, {"tcpmss",0}},
     {"retries",         SET_retries,            0,      {"retry", "max-retries", "max-retry", 0}},
     {"noreset",         SET_noreset,            F_BOOL, {0}},
     {"nmap-payloads",   SET_nmap_payloads,      0,      {"nmap-payload",0}},

--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -3242,7 +3242,10 @@ masscan_echo(struct Masscan *masscan, FILE *fp, unsigned is_echo_all)
             }
         }
         fprintf(fp, "\n");
-    }    
+    }
+    if (masscan->is_tcpmss) {
+      fprintf(fp, "tcpmss = true\n");
+    }
 }
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -1302,7 +1302,8 @@ main_scan(struct Masscan *masscan)
                     masscan->payloads.udp,
                     masscan->payloads.oproto,
                     stack_if_datalink(masscan->nic[index].adapter),
-                    masscan->seed);
+                    masscan->seed,
+                    masscan->is_tcpmss);
 
         /*
          * Set the "source port" of everything we transmit.

--- a/src/masscan.h
+++ b/src/masscan.h
@@ -183,6 +183,7 @@ struct Masscan
     unsigned is_pfring:1;       /* --pfring */
     unsigned is_sendq:1;        /* --sendq */
     unsigned is_banners:1;      /* --banners */
+    unsigned is_tcpmss:1;       /* --tcpmss */
     unsigned is_offline:1;      /* --offline */
     unsigned is_noreset:1;      /* --noreset, don't transmit RST */
     unsigned is_gmt:1;          /* --gmt, all times in GMT */

--- a/src/templ-pkt.c
+++ b/src/templ-pkt.c
@@ -425,6 +425,7 @@ tcp_create_packet(
         unsigned char *px, size_t px_length)
 {
     uint64_t xsum;
+
     if (ip_them.version == 4) {
         unsigned ip_id = ip_them.ipv4 ^ port_them ^ seqno;
         unsigned offset_ip = tmpl->ipv4.offset_ip;
@@ -439,8 +440,8 @@ tcp_create_packet(
             return 0;
         }
 
-        memcpy(px + 0,              tmpl->ipv4.packet,  tmpl->ipv4.length);
-        memcpy(px + offset_payload, payload,            payload_length);
+        memcpy(px + 0, tmpl->ipv4.packet, tmpl->ipv4.length);
+        memcpy(px + offset_payload, payload, payload_length);
         old_len = px[offset_ip+2]<<8 | px[offset_ip+3];
 
         /*
@@ -1144,7 +1145,7 @@ _template_init_ipv6(struct TemplatePacket *tmpl, macaddress_t router_mac_ipv6, u
      * contents = everything after IPv4/IPv6 header */
     offset_tcp6 = offset_ip + 40;
     memmove(buf + offset_tcp6,
-            buf + offset_tcp,       
+            buf + offset_tcp,
             payload_length
             );
 

--- a/src/templ-pkt.h
+++ b/src/templ-pkt.h
@@ -115,7 +115,8 @@ template_packet_init(
     struct PayloadsUDP *udp_payloads,
     struct PayloadsUDP *oproto_payloads,
     int data_link,
-    uint64_t entropy);
+    uint64_t entropy,
+    int tcpmss);
 
 /**
  * Sets the target/destination IP address of the packet, the destination port


### PR DESCRIPTION
This patch is associated with the discussion #326

I was considering adding this for quite a while but it seemed like a solution in search of a problem. However, I recently encountered a network that was dropping the default `masscan` SYN probes. The network 157.185.128.0/18 (QUANTIL-NETWORKS, AS54994) has this behavior. You can reproduce it using:

```
masscan -p 80,443,8000 157.185.177.217 --rate 3
```

This will not return any open ports. However, manually completing a TCP connection (with curl, telnet, whatever) works on all three ports. I tried `nmap`, using `nmap -p 80,443,8000 -sS -Pn 157.185.177.217` and saw that it worked as expected, returning all three ports as open

I quickly diffed the packets and the obvious difference was `nmap` was including a TCP MSS. I'm guessing this is some sort of border policy that drops SYN packets without any options set- quite possibly to filter `masscan` probes specifically

This patch adds `--tcpmss` (admittedly a pretty ugly name, maybe `--mss` would be better) which when specified, fixes up the TCP packet template at init time so that it contains an MSS option. It updates the IP header length and TCP header length, from 0x28 -> 0x2C and (0x5 << 2) -> (0x6 << 2) which is needed to make the packet parsing that takes place shortly after work correctly

I tested this against 157.185.177.217 using the same command as above (but with `--tcpmss` added) and received a SYN|ACK response for all three ports

I apologize for the ugliness of this code, but the code around it isn't exactly beautiful either, so I didn't spend much time trying to make it look nice. It's not focused on any sort of efficiency since it runs before the txloop even begins

