### PR TITLE
fix FreeBSD aarch64 build issue

### DIFF
--- a/src/smack1.c
+++ b/src/smack1.c
@@ -119,9 +119,8 @@
 #elif defined(__FreeBSD__)
 #include <sys/types.h>
 #include <machine/cpufunc.h>
-#define __rdtsc rdtsc
-#if (__ARM_ARCH >= 6)  // V6 is the earliest arch that has a standard cyclecount
-unsigned long long rdtsc(void)
+#if (__ARM_ARCH >= 6 && __ARM_ARCH <= 7)  // V6 is the earliest arch that has a standard cyclecount
+unsigned long long __rdtsc(void)
 {
   uint32_t pmccntr;
   uint32_t pmuseren;
@@ -138,6 +137,10 @@ unsigned long long rdtsc(void)
   }
   return 0;
 }
+#elif defined(__aarch64__)
+#define __rdtsc() 0
+#else
+#define __rdtsc rdtsc
 #endif
 #elif defined (__llvm__)
 #if defined(i386) || defined(__i386__)


### PR DESCRIPTION
Current masscan has a build issue on FreeBSD aarch64.

Error log is following:
src/smack1.c:130:16: error: unrecognized instruction mnemonic, did you mean: mrs, msr, smc?
  asm volatile("mrc p15, 0, %0, c9, c14, 0" : "=r"(pmuseren));
               ^
<inline asm>:1:2: note: instantiated into assembly here
        mrc p15, 0, x8, c9, c14, 0
        ^
src/smack1.c:132:18: error: unrecognized instruction mnemonic, did you mean: mrs, msr, smc?
    asm volatile("mrc p15, 0, %0, c9, c12, 1" : "=r"(pmcntenset));
                 ^
<inline asm>:1:2: note: instantiated into assembly here
        mrc p15, 0, x8, c9, c12, 1
        ^
src/smack1.c:134:20: error: unrecognized instruction mnemonic, did you mean: mrs, msr, smc?
      asm volatile("mrc p15, 0, %0, c9, c13, 0" : "=r"(pmccntr));
                   ^
<inline asm>:1:2: note: instantiated into assembly here
        mrc p15, 0, x8, c9, c13, 0
        ^
src/smack1.c:130:16: error: unrecognized instruction mnemonic, did you mean: mrs, msr, smc?
  asm volatile("mrc p15, 0, %0, c9, c14, 0" : "=r"(pmuseren));
               ^
<inline asm>:1:2: note: instantiated into assembly here
        mrc p15, 0, x8, c9, c14, 0
        ^
src/smack1.c:132:18: error: unrecognized instruction mnemonic, did you mean: mrs, msr, smc?
    asm volatile("mrc p15, 0, %0, c9, c12, 1" : "=r"(pmcntenset));
                 ^
<inline asm>:1:2: note: instantiated into assembly here
        mrc p15, 0, x8, c9, c12, 1
        ^
src/smack1.c:130:16: error: unrecognized instruction mnemonic, did you mean: mrs, msr, smc?
  asm volatile("mrc p15, 0, %0, c9, c14, 0" : "=r"(pmuseren));
               ^
<inline asm>:1:2: note: instantiated into assembly here
        mrc p15, 0, x8, c9, c14, 0
        ^
src/smack1.c:132:18: error: unrecognized instruction mnemonic, did you mean: mrs, msr, smc?
    asm volatile("mrc p15, 0, %0, c9, c12, 1" : "=r"(pmcntenset));
                 ^
<inline asm>:1:2: note: instantiated into assembly here
        mrc p15, 0, x8, c9, c12, 1
        ^
src/smack1.c:134:20: error: unrecognized instruction mnemonic, did you mean: mrs, msr, smc?
      asm volatile("mrc p15, 0, %0, c9, c13, 0" : "=r"(pmccntr));
                   ^
<inline asm>:1:2: note: instantiated into assembly here
        mrc p15, 0, x8, c9, c13, 0
        ^
src/smack1.c:134:20: error: unrecognized instruction mnemonic, did you mean: mrs, msr, smc?
      asm volatile("mrc p15, 0, %0, c9, c13, 0" : "=r"(pmccntr));
                   ^
<inline asm>:1:2: note: instantiated into assembly here
        mrc p15, 0, x8, c9, c13, 0
        ^
3 warnings and 9 errors generated.
gmake: *** [Makefile:109: tmp/smack1.o] Error 1


This error is due to the difference in arm assembler between the old and newer versions.
Therefore, the inline assembler can not work on later arm8 and caused errors on aarch64.
So this patch is fixed that issue.

I have tested this modification on arm6, aarch64, and amd64.
And all regression tests success.
