### PR TITLE
Fix bug in --echo for IPv6 ranges & add --echo-cidr option

### DIFF
--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -239,25 +239,27 @@ count_cidr_bits(struct Range *range, bool *exact)
 
     for (i=0; i<32; i++) {
         unsigned mask = 0xFFFFFFFF >> i;
-
+        if ((range->begin & mask) != 0) {
+            continue;
+        }
         /* if subnets are equal */
         if ((range->begin & ~mask) == (range->end & ~mask)) {
-            if ((range->begin & mask) == 0 && (range->end & mask) == mask) {
+            if ((range->end & mask) == mask) {
                 /* mask is exact, we englobe the whole range */
                 *exact = true;
                 return i;
             }
-        } else if ((range->begin & ~mask) != (range->end & ~mask)) {
+        } else {
             /* if subnets are different, we have been too far one bit */
             *exact = false;
             /* set the new range begining (that is not included
-             * in the mask we return */
+             * in the mask we return) */
             range->begin = range->begin + mask + 1;
             return i;
         }
     }
-
-    return 0;
+    range->begin += 1;
+    return 32;
 }
 
 /***************************************************************************

--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -250,7 +250,7 @@ count_cidr6_bits(struct Range6 range)
     uint64_t i;
 
     /* Kludge: can't handle more than 64-bits of CIDR ranges */
-    if (range.begin.hi != range.begin.lo)
+    if (range.begin.hi != range.end.hi)
         return 0;
 
     for (i=0; i<64; i++) {
@@ -258,7 +258,7 @@ count_cidr6_bits(struct Range6 range)
 
         if ((range.begin.lo & ~mask) == (range.end.lo & ~mask)) {
             if ((range.begin.lo & mask) == 0 && (range.end.lo & mask) == mask)
-                return (unsigned)i;
+                return (unsigned)64 + i;
         }
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1799,6 +1799,11 @@ int main(int argc, char *argv[])
         exit(0);
         break;
 
+    case Operation_EchoCidr:
+        masscan_echo_cidr(masscan, stdout, 0);
+        exit(0);
+        break;
+
     case Operation_Selftest:
         /*
          * Do a regression test of all the significant units

--- a/src/masscan.h
+++ b/src/masscan.h
@@ -36,6 +36,7 @@ enum Operation {
     Operation_Benchmark = 8,        /* --benchmark */
     Operation_Echo = 9,             /* --echo */
     Operation_EchoAll = 10,         /* --echo-all */
+    Operation_EchoCidr = 11,        /* --echo-cidr */
 };
 
 /**
@@ -534,5 +535,11 @@ masscan_initialize_adapter(
  */
 void
 masscan_echo(struct Masscan *masscan, FILE *fp, unsigned is_echo_all);
+
+/**
+ * Echoes the list of CIDR ranges to scan.
+ */
+void
+masscan_echo_cidr(struct Masscan *masscan, FILE *fp, unsigned is_echo_all);
 
 #endif


### PR DESCRIPTION
This PR does 2 things:
* it aims to addresses Issue #677 -- see details below
* it adds a new CLI option `--echo-cidr` to output IP addresses at CIDR format (`X.Y.Z.T/M`) instead of range format (`X1.Y1.Z1.T1-X2.Y2.Z2.T2`) -- see details below

These two things are in one PR because they modify the same parts of the code - two different PR would lead to merge conflicts.

---

## Address Issue #677

* fix bug in "small" CIDR ranges (/65../128)
* handle "large" CIDR ranges (/0../63)

```
$ bin/masscan --echo :: ::1
seed = 6069904213427194911
rate = 100       
shard = 1/1
nocapture = servername
nocapture = servername


# TARGET SELECTION (IP, PORTS, EXCLUDES)
ports = 
range = ::/127
```

```
$ bin/masscan --echo 2000:: 2000::1
seed = 2054565738792150746
rate = 100       
shard = 1/1
nocapture = servername
nocapture = servername


# TARGET SELECTION (IP, PORTS, EXCLUDES)
ports = 
range = 2000::/127
```

```
$ bin/masscan --echo 2000::/63
seed = 14647153754214998088
rate = 100       
shard = 1/1
nocapture = servername
nocapture = servername


# TARGET SELECTION (IP, PORTS, EXCLUDES)
ports = 
range = 2000::/63
```

```
$ bin/masscan --echo 2000::-2000:ffff:ffff:ffff:ffff:ffff:ffff:ffff
seed = 3141632608958804321
rate = 100       
shard = 1/1
nocapture = servername
nocapture = servername


# TARGET SELECTION (IP, PORTS, EXCLUDES)
ports = 
range = 2000::/16
```

---

## Add `--echo-cidr` CLI option

If I am not mistaken, there is currently no option in **masscan** to output the list of IP ranges to be scanned:

* ordered by numerical order of the first IP of each range
* only using CIDR notations (`<first ip>/<mask>`).

Indeed, the option `-sL` outputs a list of IP addresses (not ranges) in a random order, and `--echo` outputs **masscan** configuration, including ranges but also other options, and in a non-consistent format.

This PR adds the option `--echo-cidr` that outputs the the ordered list of CIDR ranges.
For instance, with the following list of IP addresses to scan:

```
10.0.0.0-10.0.1.15
192.168.0.0-192.168.0.3
192.168.1.2-192.168.1.3
```

* `masscan -iL ips.txt --echo-cidr`
```
10.0.0.0/24
10.0.1.0/28
192.168.0.0/30
192.168.1.2/31
```

* `masscan -iL ips.txt -sL | head -n 10`
```
10.0.0.111
10.0.0.61
10.0.0.82
192.168.0.3
10.0.0.190
10.0.0.214
10.0.0.121
10.0.0.42
10.0.0.193
10.0.1.4
```

* `masscan -iL ips.txt --echo`
```
seed = 7008350106479622823
rate = 100       
shard = 1/1
nocapture = servername
nocapture = servername


# TARGET SELECTION (IP, PORTS, EXCLUDES)
ports = 
range = 10.0.0.0-10.0.1.15
range = 192.168.0.0/30
range = 192.168.1.2/31
```