### PR TITLE
Add support for redis auth

### DIFF
--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -2461,6 +2461,8 @@ masscan_set_parameter(struct Masscan *masscan,
         strcpy_s(masscan->output.filename, 
                  sizeof(masscan->output.filename), 
                  "<redis>");
+    } else if(EQUALS("redis-pwd", name)) {
+        masscan->redis.password = strdup(value);
     } else if (EQUALS("release-memory", name)) {
         fprintf(stderr, "nmap(%s): this is our default option\n", name);
     } else if (EQUALS("resume", name)) {

--- a/src/main.c
+++ b/src/main.c
@@ -1596,6 +1596,7 @@ int main(int argc, char *argv[])
     masscan->shard.one = 1;
     masscan->shard.of = 1;
     masscan->min_packet_size = 60;
+    masscan->redis.password = NULL;
     masscan->payloads.udp = payloads_udp_create();
     masscan->payloads.oproto = payloads_oproto_create();
     strcpy_s(   masscan->output.rotate.directory,

--- a/src/masscan.h
+++ b/src/masscan.h
@@ -448,6 +448,7 @@ struct Masscan
 
     struct {
         ipaddress ip;
+        char    *password;
         unsigned port;
     } redis;
 

--- a/src/output.c
+++ b/src/output.c
@@ -390,6 +390,7 @@ output_create(const struct Masscan *masscan, unsigned thread_index)
     out->rotate.filesize = masscan->output.rotate.filesize;
     out->redis.port = masscan->redis.port;
     out->redis.ip = masscan->redis.ip;
+    out->redis.password = masscan ->redis.password;
     out->is_banner = masscan->is_banners;
     out->is_gmt = masscan->is_gmt;
     out->is_interactive = masscan->output.is_interactive;

--- a/src/output.h
+++ b/src/output.h
@@ -116,6 +116,7 @@ struct Output
     struct {
         ipaddress ip;
         unsigned port;
+        char *password;
         ptrdiff_t fd;
         uint64_t outstanding;
         unsigned state;


### PR DESCRIPTION
Auth-enabled Redis is always used in distributed scan scenarios.