### PR TITLE
Fix printing SNMP Integer varbind into banner

### DIFF
--- a/src/proto-snmp.c
+++ b/src/proto-snmp.c
@@ -275,7 +275,7 @@ snmp_banner(const unsigned char *oid, size_t oid_length,
             uint64_t result = 0;
             for (i=0; i<var_length; i++)
                 result = result<<8 | var[i];
-            sprintf_s(foo, sizeof(foo), "%" PRIu64 "", (uint64_t)(size_t)foo);
+            sprintf_s(foo, sizeof(foo), "%" PRIu64 "", result);
             banout_append(banout, PROTO_SNMP, foo, strlen(foo));
         }
         break;


### PR DESCRIPTION
This change fixes code which was supposed to output SNMP INTEGER32 VarBind into `banner`.