### PR TITLE
Update stub-pcap.c to support centos 7

### DIFF
--- a/src/stub-pcap.c
+++ b/src/stub-pcap.c
@@ -371,6 +371,7 @@ if (pl->datalink == NULL) pl->func_err=1, pl->datalink = null_##PCAP_DATALINK;
             "libpcap.so",
             "libpcap.A.dylib",
             "libpcap.dylib",
+            "libpcap.so.1",
             "libpcap.so.0.9.5",
             "libpcap.so.0.9.4",
             "libpcap.so.0.8",


### PR DESCRIPTION
On CentOS7 libpcap is installed as libpcap.so.1, adding thisto possible names