### PR TITLE
Integration

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1843,6 +1843,7 @@ int main(int argc, char *argv[])
             x += zeroaccess_selftest();
             x += nmapserviceprobes_selftest();
             x += rstfilter_selftest();
+            x += masscan_app_selftest();
 
 
             if (x != 0) {

--- a/src/masscan-app.c
+++ b/src/masscan-app.c
@@ -34,8 +34,7 @@ masscan_app_to_string(enum ApplicationProtocol proto)
     case PROTO_VULN:    return "vuln";
     case PROTO_HEARTBLEED:    return "heartbleed";
     case PROTO_TICKETBLEED:    return "ticketbleed";
-    case PROTO_VNC_RFB: return "vnc";
-    case PROTO_VNC_INFO: return "vnc-info";
+    case PROTO_VNC_OLD: return "vnc";
     case PROTO_SAFE:    return "safe";
     case PROTO_MEMCACHED: return "memcached";
     case PROTO_SCRIPTING:      return "scripting";
@@ -44,9 +43,11 @@ masscan_app_to_string(enum ApplicationProtocol proto)
     case PROTO_TELNET:         return "telnet";
     case PROTO_RDP:            return "rdp";
     case PROTO_HTTP_SERVER:     return "http.server";
-    case PROTO_MC:     return "minecraft";
-
-    case PROTO_ERROR: return "error";
+    case PROTO_MC:              return "minecraft";
+    case PROTO_VNC_RFB:         return "vnc";
+    case PROTO_VNC_INFO:        return "vnc-info";
+        
+    case PROTO_ERROR:           return "error";
             
     default:
         sprintf_s(tmp, sizeof(tmp), "(%u)", proto);
@@ -85,8 +86,7 @@ masscan_string_to_app(const char *str)
         {"vuln",        PROTO_VULN},
         {"heartbleed",  PROTO_HEARTBLEED},
         {"ticketbleed", PROTO_TICKETBLEED},
-        {"vnc",         PROTO_VNC_RFB},
-        {"vnc",         PROTO_VNC_INFO},
+        {"vnc-old",     PROTO_VNC_OLD},
         {"safe",        PROTO_SAFE},
         {"memcached",   PROTO_MEMCACHED},
         {"scripting",   PROTO_SCRIPTING},
@@ -96,6 +96,8 @@ masscan_string_to_app(const char *str)
         {"rdp",         PROTO_RDP},
         {"http.server", PROTO_HTTP_SERVER},
         {"minecraft",   PROTO_MC},
+        {"vnc",         PROTO_VNC_RFB},
+        {"vnc-info",    PROTO_VNC_INFO},
         {0,0}
     };
     size_t i;
@@ -104,5 +106,38 @@ masscan_string_to_app(const char *str)
         if (strcmp(str, list[i].name) == 0)
             return list[i].value;
     }
+    return 0;
+}
+
+int
+masscan_app_selftest(void) {
+    static const struct {
+        unsigned enumid;
+        unsigned expected;
+    } tests[] = {
+        {PROTO_SNMP, 7},
+        {PROTO_X509_CERT, 15},
+        {PROTO_HTTP_SERVER, 31},
+        {0,0}
+    };
+    size_t i;
+    
+    /* The ENUM contains fixed values in external files,
+     * so programmers should only add onto its end, not
+     * the middle. This self-test will verify that
+     * a programmer hasn't made this mistake.
+     */
+    for (i=0; tests[i].enumid != 0; i++) {
+        unsigned enumid = tests[i].enumid;
+        unsigned expected = tests[i].expected;
+        
+        /* YOU ADDED AN ENUM IN THE MIDDLE INSTEAD ON THE END OF THE LIST */
+        if (enumid != expected) {
+            fprintf(stderr, "[-] %s:%u fail\n", __FILE__, (unsigned)__LINE__);
+            fprintf(stderr, "[-] enum expected=%u, found=%u\n", 30, PROTO_HTTP_SERVER);
+            return 1;
+        }
+    }
+    
     return 0;
 }

--- a/src/masscan-app.h
+++ b/src/masscan-app.h
@@ -13,34 +13,35 @@ enum ApplicationProtocol {
     PROTO_HTTP,
     PROTO_FTP,
     PROTO_DNS_VERSIONBIND,
-    PROTO_SNMP,             /* simple network management protocol, udp/161 */
-    PROTO_NBTSTAT,          /* netbios, udp/137 */
+    PROTO_SNMP,             /* 7 - simple network management protocol, udp/161 */
+    PROTO_NBTSTAT,          /* 8 - netbios, udp/137 */
     PROTO_SSL3,
-    PROTO_SMB,              /* SMB tcp/139 and tcp/445 */
-    PROTO_SMTP,
-    PROTO_POP3,
-    PROTO_IMAP4,
+    PROTO_SMB,              /* 10 - SMB tcp/139 and tcp/445 */
+    PROTO_SMTP,             /* 11 - transfering email */
+    PROTO_POP3,             /* 12 - fetching email */
+    PROTO_IMAP4,            /* 13 - fetching email */
     PROTO_UDP_ZEROACCESS,
-    PROTO_X509_CERT,
+    PROTO_X509_CERT,        /* 15 - just the cert */
     PROTO_X509_CACERT,
     PROTO_HTML_TITLE,
     PROTO_HTML_FULL,
-    PROTO_NTP,              /* network time protocol, udp/123 */
+    PROTO_NTP,              /* 19 - network time protocol, udp/123 */
     PROTO_VULN,
     PROTO_HEARTBLEED,
     PROTO_TICKETBLEED,
-    PROTO_VNC_RFB,
-    PROTO_VNC_INFO,
+    PROTO_VNC_OLD,
     PROTO_SAFE,
-    PROTO_MEMCACHED,
+    PROTO_MEMCACHED,        /* 25 - memcached */
     PROTO_SCRIPTING,
     PROTO_VERSIONING,
-    PROTO_COAP,         /* constrained app proto, udp/5683, RFC7252 */
-    PROTO_TELNET,
-    PROTO_RDP,          /* Microsoft Remote Desktop Protocol tcp/3389 */
-    PROTO_HTTP_SERVER,  /* HTTP "Server:" field */
-    PROTO_MC,           /* Minecraft server */
-
+    PROTO_COAP,             /* 28 - constrained app proto, udp/5683, RFC7252 */
+    PROTO_TELNET,           /* 29 - ye old remote terminal */
+    PROTO_RDP,              /* 30 - Microsoft Remote Desktop Protocol tcp/3389 */
+    PROTO_HTTP_SERVER,      /* 31 - HTTP "Server:" field */
+    PROTO_MC,               /* 32 - Minecraft server */
+    PROTO_VNC_RFB,
+    PROTO_VNC_INFO,
+    
     PROTO_ERROR,
 
     PROTO_end_of_list /* must be last one */
@@ -51,5 +52,8 @@ masscan_app_to_string(enum ApplicationProtocol proto);
 
 enum ApplicationProtocol
 masscan_string_to_app(const char *str);
+
+int
+masscan_app_selftest(void);
 
 #endif


### PR DESCRIPTION
The PROTO_ ID should only be added on the end, not in the middle. So I moved the new PROTO_VNC_INFO.
Also, I added a selftest so this mistake won't happen again.