### PR TITLE
Fixed 'expeced' typo

### DIFF
--- a/src/in-binary.c
+++ b/src/in-binary.c
@@ -507,7 +507,7 @@ _binaryfile_parse(struct Output *out, const char *filename,
     /* Make sure it's got the format string */
     if (memcmp(buf, "masscan/1.1", 11) != 0) {
         LOG(0,
-                "[-] %s: unknown file format (expeced \"masscan/1.1\")\n",
+                "[-] %s: unknown file format (expected \"masscan/1.1\")\n",
                 filename);
         goto end;
     }


### PR DESCRIPTION
Fixed a typo in `in-binary.c` on the "expeced" word, should be "expected" BUT I GOT YOU BOO 💯