### PR TITLE
#764 support multiple payloads per udp port

### DIFF
--- a/src/massip-port.h
+++ b/src/massip-port.h
@@ -21,7 +21,7 @@ enum {
     Templ_Oproto_first = 65536*3 + 256,
     Templ_Oproto_last = 65536*3 + 256 + 255,
     Templ_VulnCheck = 65536*4,
-    
+    Templ_UDP_payloads = 65536*5
 };
 
 #endif

--- a/src/templ-payloads.h
+++ b/src/templ-payloads.h
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdint.h>
 struct MassIP;
+struct RangeList;
 
 /**
  * Regression test this module.
@@ -92,23 +93,15 @@ typedef unsigned (*SET_COOKIE)(unsigned char *px, size_t length,
 int
 payloads_udp_lookup(
                 const struct PayloadsUDP *payloads,
-                unsigned port,
+                unsigned payload_index,
                 const unsigned char **px,
                 unsigned *length,
                 unsigned *source_port,
                 uint64_t *xsum,
                 SET_COOKIE *set_cookie);
 
-int
-payloads_oproto_lookup(
-                    const struct PayloadsUDP *payloads,
-                    unsigned port,
-                    const unsigned char **px,
-                    unsigned *length,
-                    unsigned *source_port,
-                    uint64_t *xsum,
-                    SET_COOKIE *set_cookie);
-
+void
+payloads_add_targets(struct RangeList *targets, const struct PayloadsUDP *payloads, unsigned begin, unsigned end);
 
 
 #endif


### PR DESCRIPTION
This MR adds support for sending multiple payloads per UDP port.

For this it:

- modifies payloads_datagram_add to allow multiple payloads per port
- adds a new "port type" for UDP payloads (instead of actual ports)
- creates a targets list in transmit_thread than can reference UDP payloads directly
- updates template_set_target_ipv4 and template_set_target_ipv6 to handle these UDP payloads

Due to these changes template_set_target_ipv4 and template_set_target_ipv6 are only called for UDP ports (rather than payloads) if no specialised payload was found.