### PR TITLE
add suite of ipv6 formatting tests, related to #796

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1822,6 +1822,7 @@ int main(int argc, char *argv[])
             x += ranges6_selftest();
             x += dedup_selftest();
             x += checksum_selftest();
+            x += ipv4address_selftest();
             x += ipv6address_selftest();
             x += proto_coap_selftest();
             x += smack_selftest();

--- a/src/massip-addr.c
+++ b/src/massip-addr.c
@@ -297,13 +297,10 @@ int ipv6address_selftest(void)
   struct ipaddress_formatted fmt;
 
   for (int i = 0; tests[i].name != NULL; i++) {
-    printf("Expected: %s\n", tests[i].name);
     fmt = ipaddress_fmt(tests[i].ip_addr);
-    printf("Actual: %s\n", fmt.string);
     if (strcmp(fmt.string, tests[i].name) != 0)
       x++;
   }
-  printf("ERRORS: %d\n", x);
   return x;
 }
 

--- a/src/massip-addr.c
+++ b/src/massip-addr.c
@@ -275,6 +275,40 @@ ipv6address_t ipv6address_add(ipv6address_t lhs, ipv6address_t rhs) {
 
 int ipv6address_selftest(void)
 {
+  struct test_pair {
+    const char *name;             // Human-readable IPv6 address string
+    struct ipaddress ip_addr;     // IP address (union)
+  };
+  /* Probably overkill, added while investigating issue #796 */
+  struct test_pair tests[] = {
+      {"2001:db8:ac10:fe01::2", {.ipv6 = {0x20010db8ac10fe01, 0x0000000000000002}, .version = 6}},
+      {"2607:f8b0:4000::1", {.ipv6 = {0x2607f8b040000000, 0x0000000000000001}, .version = 6}},
+      {"fd12:3456:7890:abcd:ef00::1", {.ipv6 = {0xfd1234567890abcd, 0xef00000000000001}, .version = 6}},
+      {"::1", {.ipv6 = {0x0000000000000000, 0x0000000000000001}, .version = 6}},
+      {"1::", {.ipv6 = {0x0001000000000000, 0x0000000000000000}, .version = 6}},
+      {"1::2", {.ipv6 = {0x0001000000000000, 0x0000000000000002}, .version = 6}},
+      {"2::1", {.ipv6 = {0x0002000000000000, 0x0000000000000001}, .version = 6}},
+      {"1:2::", {.ipv6 = {0x0001000200000000, 0x0000000000000000}, .version = 6}},
+      {NULL, {{0, 0}, 0}}
+  };
+
+  int x = 0;
+  ipaddress ip;
+  struct ipaddress_formatted fmt;
+
+  for (int i = 0; tests[i].name != NULL; i++) {
+    printf("Expected: %s\n", tests[i].name);
+    fmt = ipaddress_fmt(tests[i].ip_addr);
+    printf("Actual: %s\n", fmt.string);
+    if (strcmp(fmt.string, tests[i].name) != 0)
+      x++;
+  }
+  printf("ERRORS: %d\n", x);
+  return x;
+}
+
+int ipv4address_selftest(void)
+{
     int x = 0;
     ipaddress ip;
     struct ipaddress_formatted fmt;

--- a/src/massip-addr.h
+++ b/src/massip-addr.h
@@ -194,5 +194,6 @@ unsigned massint128_bitcount(massint128_t num);
  * @return 0 on success, 1 on failure
  */
 int ipv6address_selftest(void);
+int ipv4address_selftest(void);
 
 #endif


### PR DESCRIPTION
I split out the oddly named test function for address formatting (named for ipv6, but had only a single test case, for ipv4)

I did this when trying to track down #796

Unfortunately, I didn't find any issues .... if anyone wants to take a look, feel free. I think more information is needed to reproduce the behavior that is reported there