### PR TITLE
Fix LNK2001 error on Visual Studio

### DIFF
--- a/vs10/masscan.vcxproj
+++ b/vs10/masscan.vcxproj
@@ -125,6 +125,7 @@
     <ClCompile Include="..\src\templ-tcp-hdr.c" />
     <ClCompile Include="..\src\util-checksum.c" />
     <ClCompile Include="..\src\util-errormsg.c" />
+    <ClCompile Include="..\src\util-extract.c" />
     <ClCompile Include="..\src\util-logger.c" />
     <ClCompile Include="..\src\util-malloc.c" />
     <ClCompile Include="..\src\util-safefunc.c" />


### PR DESCRIPTION
When building on Visual Studio, some symbols in util-extract.c aren't included, resulting in linker errors. This PR adds this file to the Visual Studio project file, allowing it to compile successfully.