### PR TITLE
Flush file buffer when using stdout

### DIFF
--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -218,6 +218,7 @@ print_nmap_help(void)
 "  -oL/-oJ/-oD/-oG/-oB/-oX/-oU <file>: Output scan in List/JSON/nDjson/Grepable/Binary/XML/Unicornscan format,\n"
 "     respectively, to the given filename. Shortcut for\n"
 "     --output-format <format> --output-file <file>\n"
+"  --output-flush: Flushes output per host found (recommended for real-time reading).\n"
 "  -v: Increase verbosity level (use -vv or more for greater effect)\n"
 "  -d: Increase debugging level (use -dd or more for greater effect)\n"
 "  --open: Only show open (or possibly open) ports\n"
@@ -1128,15 +1129,15 @@ static int SET_banners_rawudp(struct Masscan *masscan, const char *name, const c
     return CONF_OK;
 }
 
-static int SET_flush_stdout(struct Masscan *masscan, const char *name, const char *value)
+static int SET_output_flush(struct Masscan *masscan, const char *name, const char *value)
 {
     UNUSEDPARM(name);
     if (masscan->echo) {
-        if (masscan->is_flush_stdout || masscan->echo_all)
-            fprintf(masscan->echo, "flush-stdout = %s\n", masscan->is_flush_stdout?"true":"false");
+        if (masscan->is_output_flush || masscan->echo_all)
+            fprintf(masscan->echo, "flush-stdout = %s\n", masscan->is_output_flush?"true":"false");
        return 0;
     }
-    masscan->is_flush_stdout = parseBoolean(value);
+    masscan->is_output_flush = parseBoolean(value);
     return CONF_OK;
 }
 
@@ -2375,7 +2376,7 @@ struct ConfigParameter config_parameters[] = {
     {"shard",           SET_shard,              0,      {"shards",0}},
     {"banners",         SET_banners,            F_BOOL, {"banner",0}}, /* --banners */
     {"rawudp",          SET_banners_rawudp,     F_BOOL, {"rawudp",0}}, /* --rawudp */
-    {"flush-stdout",    SET_flush_stdout,       F_BOOL, {"flush-stdout",0}}, /* --flush-stdout" */
+    {"output-flush",    SET_output_flush,       F_BOOL, {"output-flush",0}}, /* --output-flush" */
     {"nobanners",       SET_nobanners,          F_BOOL, {"nobanner",0}},
     {"retries",         SET_retries,            0,      {"retry", "max-retries", "max-retry", 0}},
     {"noreset",         SET_noreset,            F_BOOL, {0}},

--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -1128,6 +1128,18 @@ static int SET_banners_rawudp(struct Masscan *masscan, const char *name, const c
     return CONF_OK;
 }
 
+static int SET_flush_stdout(struct Masscan *masscan, const char *name, const char *value)
+{
+    UNUSEDPARM(name);
+    if (masscan->echo) {
+        if (masscan->is_flush_stdout || masscan->echo_all)
+            fprintf(masscan->echo, "flush-stdout = %s\n", masscan->is_flush_stdout?"true":"false");
+       return 0;
+    }
+    masscan->is_flush_stdout = parseBoolean(value);
+    return CONF_OK;
+}
+
 static int SET_capture(struct Masscan *masscan, const char *name, const char *value)
 {
     if (masscan->echo) {
@@ -2363,6 +2375,7 @@ struct ConfigParameter config_parameters[] = {
     {"shard",           SET_shard,              0,      {"shards",0}},
     {"banners",         SET_banners,            F_BOOL, {"banner",0}}, /* --banners */
     {"rawudp",          SET_banners_rawudp,     F_BOOL, {"rawudp",0}}, /* --rawudp */
+    {"flush-stdout",    SET_flush_stdout,       F_BOOL, {"flush-stdout",0}}, /* --flush-stdout" */
     {"nobanners",       SET_nobanners,          F_BOOL, {"nobanner",0}},
     {"retries",         SET_retries,            0,      {"retry", "max-retries", "max-retry", 0}},
     {"noreset",         SET_noreset,            F_BOOL, {0}},

--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -1129,18 +1129,6 @@ static int SET_banners_rawudp(struct Masscan *masscan, const char *name, const c
     return CONF_OK;
 }
 
-static int SET_output_flush(struct Masscan *masscan, const char *name, const char *value)
-{
-    UNUSEDPARM(name);
-    if (masscan->echo) {
-        if (masscan->is_output_flush || masscan->echo_all)
-            fprintf(masscan->echo, "flush-stdout = %s\n", masscan->is_output_flush?"true":"false");
-       return 0;
-    }
-    masscan->is_output_flush = parseBoolean(value);
-    return CONF_OK;
-}
-
 static int SET_capture(struct Masscan *masscan, const char *name, const char *value)
 {
     if (masscan->echo) {
@@ -1637,6 +1625,18 @@ static int SET_output_append(struct Masscan *masscan, const char *name, const ch
         masscan->output.is_append = 0;
     else
         masscan->output.is_append = 1;
+    return CONF_OK;
+}
+
+static int SET_output_flush(struct Masscan *masscan, const char *name, const char *value)
+{
+    UNUSEDPARM(name);
+    if (masscan->echo) {
+        if (masscan->output.is_output_flush || masscan->echo_all)
+            fprintf(masscan->echo, "output-flush = %s\n", masscan->output.is_output_flush?"true":"false");
+       return 0;
+    }
+    masscan->output.is_output_flush = parseBoolean(value);
     return CONF_OK;
 }
 
@@ -2376,7 +2376,6 @@ struct ConfigParameter config_parameters[] = {
     {"shard",           SET_shard,              0,      {"shards",0}},
     {"banners",         SET_banners,            F_BOOL, {"banner",0}}, /* --banners */
     {"rawudp",          SET_banners_rawudp,     F_BOOL, {"rawudp",0}}, /* --rawudp */
-    {"output-flush",    SET_output_flush,       F_BOOL, {"output-flush",0}}, /* --output-flush" */
     {"nobanners",       SET_nobanners,          F_BOOL, {"nobanner",0}},
     {"retries",         SET_retries,            0,      {"retry", "max-retries", "max-retry", 0}},
     {"noreset",         SET_noreset,            F_BOOL, {0}},
@@ -2409,6 +2408,7 @@ struct ConfigParameter config_parameters[] = {
     {"output-noshow",   SET_output_noshow,      0,      {"noshow",0}},
     {"output-show-open",SET_output_show_open,   F_BOOL, {"open", "open-only", 0}},
     {"output-append",   SET_output_append,      0,      {"append-output",0}},
+    {"output-flush",    SET_output_flush,       F_BOOL, {"output-flush",0}},
     {"rotate",          SET_rotate_time,        0,      {"output-rotate", "rotate-output", "rotate-time", 0}},
     {"rotate-dir",      SET_rotate_directory,   0,      {"output-rotate-dir", "rotate-directory", 0}},
     {"rotate-offset",   SET_rotate_offset,      0,      {"output-rotate-offset", 0}},

--- a/src/masscan.h
+++ b/src/masscan.h
@@ -188,7 +188,7 @@ struct Masscan
     unsigned is_sendq:1;        /* --sendq */
     unsigned is_banners:1;      /* --banners */
     unsigned is_banners_rawudp:1; /* --rawudp */
-    unsigned is_flush_stdout:1; /* --flush-stdout */
+    unsigned is_output_flush:1; /* --output-flush */
     unsigned is_offline:1;      /* --offline */
     unsigned is_noreset:1;      /* --noreset, don't transmit RST */
     unsigned is_gmt:1;          /* --gmt, all times in GMT */

--- a/src/masscan.h
+++ b/src/masscan.h
@@ -283,13 +283,6 @@ struct Masscan
         char filename[256];
 
         /**
-         * --output-flush
-         * We should flush the file with every host/banner found
-         */
-        unsigned is_output_flush:1;
-
-
-        /**
          * A feature of the XML output where we can insert an optional 
          * stylesheet into the file for better rendering on web browsers
          */
@@ -350,6 +343,12 @@ struct Masscan
         * Print state updates
         */
         unsigned is_status_updates:1;
+
+        /**
+         * --output-flush
+         * Flush the file with every host/banner found
+         */
+        unsigned is_output_flush:1;
 
         struct {
             /**

--- a/src/masscan.h
+++ b/src/masscan.h
@@ -188,7 +188,6 @@ struct Masscan
     unsigned is_sendq:1;        /* --sendq */
     unsigned is_banners:1;      /* --banners */
     unsigned is_banners_rawudp:1; /* --rawudp */
-    unsigned is_output_flush:1; /* --output-flush */
     unsigned is_offline:1;      /* --offline */
     unsigned is_noreset:1;      /* --noreset, don't transmit RST */
     unsigned is_gmt:1;          /* --gmt, all times in GMT */
@@ -282,7 +281,14 @@ struct Masscan
          * <stdout> rather than to a file.
          */
         char filename[256];
-        
+
+        /**
+         * --output-flush
+         * We should flush the file with every host/banner found
+         */
+        unsigned is_output_flush:1;
+
+
         /**
          * A feature of the XML output where we can insert an optional 
          * stylesheet into the file for better rendering on web browsers

--- a/src/masscan.h
+++ b/src/masscan.h
@@ -188,6 +188,7 @@ struct Masscan
     unsigned is_sendq:1;        /* --sendq */
     unsigned is_banners:1;      /* --banners */
     unsigned is_banners_rawudp:1; /* --rawudp */
+    unsigned is_flush_stdout:1; /* --flush-stdout */
     unsigned is_offline:1;      /* --offline */
     unsigned is_noreset:1;      /* --noreset, don't transmit RST */
     unsigned is_gmt:1;          /* --gmt, all times in GMT */

--- a/src/out-text.c
+++ b/src/out-text.c
@@ -13,6 +13,7 @@ text_out_open(struct Output *out, FILE *fp)
 {
     UNUSEDPARM(out);
     fprintf(fp, "#masscan\n");
+    fflush(fp);
 }
 
 /****************************************************************************
@@ -22,6 +23,7 @@ text_out_close(struct Output *out, FILE *fp)
 {
     UNUSEDPARM(out);
     fprintf(fp, "# end\n");
+    fflush(fp);
 }
 
 /****************************************************************************
@@ -43,6 +45,7 @@ text_out_status(struct Output *out, FILE *fp, time_t timestamp,
         fmt.string,
         (unsigned)timestamp
         );
+    fflush(fp);
 }
 
 
@@ -70,6 +73,7 @@ text_out_banner(struct Output *out, FILE *fp, time_t timestamp,
         masscan_app_to_string(proto),
         normalize_string(px, length, banner_buffer, sizeof(banner_buffer))
         );
+    fflush(fp);
 }
 
 

--- a/src/out-text.c
+++ b/src/out-text.c
@@ -13,7 +13,6 @@ text_out_open(struct Output *out, FILE *fp)
 {
     UNUSEDPARM(out);
     fprintf(fp, "#masscan\n");
-    fflush(fp);
 }
 
 /****************************************************************************
@@ -23,7 +22,6 @@ text_out_close(struct Output *out, FILE *fp)
 {
     UNUSEDPARM(out);
     fprintf(fp, "# end\n");
-    fflush(fp);
 }
 
 /****************************************************************************
@@ -45,7 +43,6 @@ text_out_status(struct Output *out, FILE *fp, time_t timestamp,
         fmt.string,
         (unsigned)timestamp
         );
-    fflush(fp);
 }
 
 
@@ -73,7 +70,6 @@ text_out_banner(struct Output *out, FILE *fp, time_t timestamp,
         masscan_app_to_string(proto),
         normalize_string(px, length, banner_buffer, sizeof(banner_buffer))
         );
-    fflush(fp);
 }
 
 

--- a/src/output.c
+++ b/src/output.c
@@ -860,6 +860,9 @@ output_report_status(struct Output *out, time_t timestamp, int status,
      * and so on.
      */
     out->funcs->status(out, fp, timestamp, status, ip, ip_proto, port, reason, ttl);
+
+    if (fp == stdout)
+        fflush(fp);
 }
 
 

--- a/src/output.c
+++ b/src/output.c
@@ -396,6 +396,7 @@ output_create(const struct Masscan *masscan, unsigned thread_index)
     out->redis.password = masscan ->redis.password;
     out->is_banner = masscan->is_banners;               /* --banners */
     out->is_banner_rawudp = masscan->is_banners_rawudp; /* --rawudp */
+    out->is_flush_stdout = masscan->is_flush_stdout;    /* --flush-stdout */
     out->is_gmt = masscan->is_gmt;
     out->is_interactive = masscan->output.is_interactive;
     out->is_show_open = masscan->output.is_show_open;
@@ -861,7 +862,7 @@ output_report_status(struct Output *out, time_t timestamp, int status,
      */
     out->funcs->status(out, fp, timestamp, status, ip, ip_proto, port, reason, ttl);
 
-    if (fp == stdout)
+    if (out->is_flush_stdout && fp == stdout)
         fflush(fp);
 }
 
@@ -937,6 +938,8 @@ output_report_banner(struct Output *out, time_t now,
      */
     out->funcs->banner(out, fp, now, ip, ip_proto, port, proto, ttl, px, length);
 
+    if (out->is_flush_stdout && fp == stdout)
+        fflush(fp);
 }
 
 

--- a/src/output.c
+++ b/src/output.c
@@ -396,7 +396,7 @@ output_create(const struct Masscan *masscan, unsigned thread_index)
     out->redis.password = masscan ->redis.password;
     out->is_banner = masscan->is_banners;               /* --banners */
     out->is_banner_rawudp = masscan->is_banners_rawudp; /* --rawudp */
-    out->is_flush_stdout = masscan->is_flush_stdout;    /* --flush-stdout */
+    out->is_output_flush = masscan->is_output_flush;    /* --flush-stdout */
     out->is_gmt = masscan->is_gmt;
     out->is_interactive = masscan->output.is_interactive;
     out->is_show_open = masscan->output.is_show_open;
@@ -862,7 +862,7 @@ output_report_status(struct Output *out, time_t timestamp, int status,
      */
     out->funcs->status(out, fp, timestamp, status, ip, ip_proto, port, reason, ttl);
 
-    if (out->is_flush_stdout && fp == stdout)
+    if (out->is_output_flush)
         fflush(fp);
 }
 
@@ -938,7 +938,7 @@ output_report_banner(struct Output *out, time_t now,
      */
     out->funcs->banner(out, fp, now, ip, ip_proto, port, proto, ttl, px, length);
 
-    if (out->is_flush_stdout && fp == stdout)
+    if (out->is_output_flush)
         fflush(fp);
 }
 

--- a/src/output.c
+++ b/src/output.c
@@ -396,13 +396,13 @@ output_create(const struct Masscan *masscan, unsigned thread_index)
     out->redis.password = masscan ->redis.password;
     out->is_banner = masscan->is_banners;               /* --banners */
     out->is_banner_rawudp = masscan->is_banners_rawudp; /* --rawudp */
-    out->is_output_flush = masscan->is_output_flush;    /* --flush-stdout */
     out->is_gmt = masscan->is_gmt;
     out->is_interactive = masscan->output.is_interactive;
     out->is_show_open = masscan->output.is_show_open;
     out->is_show_closed = masscan->output.is_show_closed;
     out->is_show_host = masscan->output.is_show_host;
     out->is_append = masscan->output.is_append;
+    out->is_output_flush = masscan->output.is_output_flush;
     out->xml.stylesheet = duplicate_string(masscan->output.stylesheet);
     out->rotate.directory = duplicate_string(masscan->output.rotate.directory);
     if (masscan->nic_count <= 1)

--- a/src/output.h
+++ b/src/output.h
@@ -83,7 +83,7 @@ struct Output
 
     unsigned is_banner:1;           /* --banners */
     unsigned is_banner_rawudp:1;    /* --rawudp */
-    unsigned is_flush_stdout:1;     /* --flush-stdout */
+    unsigned is_output_flush:1;     /* --output-flush */
     unsigned is_gmt:1; /* --gmt */
     unsigned is_interactive:1; /* echo to command line */
     unsigned is_show_open:1; /* show open ports (default) */

--- a/src/output.h
+++ b/src/output.h
@@ -83,6 +83,7 @@ struct Output
 
     unsigned is_banner:1;           /* --banners */
     unsigned is_banner_rawudp:1;    /* --rawudp */
+    unsigned is_flush_stdout:1;     /* --flush-stdout */
     unsigned is_gmt:1; /* --gmt */
     unsigned is_interactive:1; /* echo to command line */
     unsigned is_show_open:1; /* show open ports (default) */


### PR DESCRIPTION
Currently, Masscan does not flush the file buffer when using the `-oL -` flags. This does not allow other programs (in my case, Python) to easily parse the output stream.

Here's the code I'm using in case anyone wants to reproduce the issue.
```py
import subprocess

def masscan_iterate(path, port, rate=1000):
        process = subprocess.Popen(
                [
                        path,
                        "-oL", "-",
                        "-p", str(port),
                        "--rate", str(rate),
                        "--exclude", "255.255.255.255",
                        "0.0.0.0/0",
                        "--output-flush", # Added by this PR
                ],
                stdout = subprocess.PIPE,
                stderr = subprocess.DEVNULL
        )

        while process.poll() == None:
                line = process.stdout.readline() # Hangs with the current Masscan version, works with the PR

                if line != b'':
                        print(line)

masscan_iterate("./masscan", 22)
```
