### PR TITLE
"bad cookie" log levels warnings are inconsistent

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -970,7 +970,7 @@ receive_thread(void *v)
             if (TCP_IS_SYNACK(px, parsed.transport_offset)) {
                 if (cookie != seqno_me - 1) {
                     ipaddress_formatted_t fmt = ipaddress_fmt(ip_them);
-                    LOG(0, "%s - bad cookie: ackno=0x%08x expected=0x%08x\n",
+                    LOG(2, "%s - bad cookie: ackno=0x%08x expected=0x%08x\n",
                         fmt.string, seqno_me-1, cookie);
                     continue;
                 }


### PR DESCRIPTION
The other "bad cookie" warning is level 2:
https://github.com/robertdavidgraham/masscan/blob/a31feaf5c943fc517752e23423ea130a92f0d473/src/main.c#L1061
this other one occurs in --banners, it makes sense for them to be consistent