### PR TITLE
Fix bug in banout_vprintf

### DIFF
--- a/src/proto-banout.c
+++ b/src/proto-banout.c
@@ -297,8 +297,11 @@ banout_vprintf(struct BannerOutput *banout, unsigned proto,
                const char *fmt, va_list marker) {
     char str[10];
     int len;
+    va_list marker_cpy;  // a va_list is consumed when passed to vsnprintf.
     
-    len = vsnprintf(str, sizeof(str), fmt, marker);
+    va_copy(marker_cpy, marker);
+    len = vsnprintf(str, sizeof(str), fmt, marker_cpy);
+    va_end(marker_cpy);
     if (len > sizeof(str)-1) {
         char *tmp = malloc(len+1);
         vsnprintf(tmp, len+1, fmt, marker);


### PR DESCRIPTION
Not really sure how nobody noticed, but at least on my
> gcc version 14.2.0 (Debian 14.2.0-16)


```sh
$ ./bin/masscan --selftest
======================================================================
 Segmentation fault: please post this backtrace to:
 https://github.com/robertdavidgraham/masscan/issues
======================================================================
13: [./bin/masscan(+0xa871) [0x55e644345871]]
?? ??:0
[....]
```

`marker` is consumed when used in the first `vnsprintf`, resulting in a segfault in the second. See https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/va-arg-va-copy-va-end-va-start?view=msvc-170