### PR TITLE
Allow inline comments in nmap payload file

### DIFF
--- a/src/templ-nmap-payloads.c
+++ b/src/templ-nmap-payloads.c
@@ -245,6 +245,8 @@ read_nmap_payloads(FILE *fp, const char *filename,
             p = parse_c_string(buf, &buf_length, sizeof(buf), line);
             memmove(line, p, strlen(p)+1);
             trim(line, sizeof(line));
+            if (*line == '#')
+                line[0] = '\0';
         }
 
         /* [source] */


### PR DESCRIPTION
Inline comments are currently not handled. For example, this nmap-payloads file would work:
```
# send packet
udp 12345
  "\x01\0x02"
```
but this wouldn't:
```
udp 12345
  "\x01" # packet id
  "\0x02" # data
```