### PR TITLE
fix: broken PF_RING install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ network needs to be able to route IPv6 packets.
 ## PF_RING
 
 To get beyond 2 million packets/second, you need an Intel 10-gbps Ethernet
-adapter and a special driver known as ["PF_RING ZC" from ntop](http://www.ntop.org/products/packet-capture/pf_ring/pf_ring-zc-zero-copy/). Masscan doesn't need to be rebuilt in order to use PF_RING. To use PF_RING,
+adapter and a special driver known as ["PF_RING ZC" from ntop](https://www.ntop.org/installation-guide-for-pf_ring/). Masscan doesn't need to be rebuilt in order to use PF_RING. To use PF_RING,
 you need to build the following components:
 
   * `libpfring.so` (installed in /usr/lib/libpfring.so)


### PR DESCRIPTION
The old link to `PF_RING` was not working properly, so I replaced it.