### PR TITLE
Flush output buffer after writing status/banner to stdout

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -860,6 +860,13 @@ output_report_status(struct Output *out, time_t timestamp, int status,
      * and so on.
      */
     out->funcs->status(out, fp, timestamp, status, ip, ip_proto, port, reason, ttl);
+
+    /*
+     * If outputting to stdout, flush the buffer immediately
+     */
+    if (fp == stdout)
+        fflush(fp);
+
 }
 
 
@@ -933,6 +940,12 @@ output_report_banner(struct Output *out, time_t now,
      * and so on.
      */
     out->funcs->banner(out, fp, now, ip, ip_proto, port, proto, ttl, px, length);
+
+    /*
+     * If outputting to stdout, flush the buffer immediately
+     */
+    if (fp == stdout)
+        fflush(fp);
 
 }
 


### PR DESCRIPTION
Currently, masscan does not call `fflush` on the output handle after writing status/banner. When writing output to a file (where buffering is desirable) or to a console (which is not buffered), this is not an issue. However, when piping masscan's output to a script, the output buffering causes the other end of the pipe to not receive any scan results until either enough have been buffered for the handle to flush itself, or otherwise until the scan is complete and the handle is closed.

This PR fixes this issue by calling `fflush` after every output write when the output file is stdout.

Resolves #533 