### PR TITLE
add new 'ipport' output format for IP:PORT pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,14 @@ per line. Just use the parameter `-oL <filename>`. Or, use the parameters
 	```
 	<port state> <protocol> <port number> <IP address> <POSIX timestamp>  
 	open tcp 80 XXX.XXX.XXX.XXX 1390380064
+	```
+
+6. ipport: This is a simple list with IP:PORT pairs for open ports.
+Just use the parameter `-oI <filename>`. Or, use the parameters 
+`--output-format ipport` and `--output-filename <filename>`. The format is:
+
+	```
+	XXX.XXX.XXX.XXX:80
 	```	
 
 

--- a/doc/masscan.8.markdown
+++ b/doc/masscan.8.markdown
@@ -233,7 +233,7 @@ one port.
     no effect if used with --output-format or --output-filename.		
   
   * `--output-format FMT`: indicates the format of the output file, which
-    can be `xml`, `binary`, `grepable`, `list`, or `JSON`. The 
+    can be `xml`, `binary`, `grepable`, `list`, `json`, or `ipport`. The 
 	option `--output-filename` must be specified.
 
   * `--output-filename FILE`: the file which to save results to. If
@@ -262,6 +262,10 @@ one port.
   * `-oL FILE`: sets the output format to a simple list format and saves 
 	  the output in the given filename. This is equivalent to using 
 	  the --output-format list and --output-filename parameters.
+
+  * `-oI FILE`: sets the output format to IP:PORT format and saves 
+	  the output in the given filename. This is equivalent to using 
+	  the --output-format ipport and --output-filename parameters.
 
   *  `--readscan FILE`: reads the files created by the `-oB` option
     from a scan, then outputs them in one of the other formats, depending

--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -212,10 +212,10 @@ print_nmap_help(void)
 "  --ttl <val>: Set IP time-to-live field\n"
 "  --spoof-mac <mac address/prefix/vendor name>: Spoof your MAC address\n"
 "OUTPUT:\n"
-"  --output-format <format>: Sets output to binary/list/unicornscan/json/ndjson/grepable/xml\n"
+"  --output-format <format>: Sets output to binary/list/unicornscan/json/ndjson/grepable/xml/ipport\n"
 "  --output-file <file>: Write scan results to file. If --output-format is\n"
 "     not given default is xml\n"
-"  -oL/-oJ/-oD/-oG/-oB/-oX/-oU <file>: Output scan in List/JSON/nDjson/Grepable/Binary/XML/Unicornscan format,\n"
+"  -oL/-oJ/-oD/-oG/-oB/-oX/-oU/-oI <file>: Output scan in List/JSON/nDjson/Grepable/Binary/XML/Unicornscan/IPPort format,\n"
 "     respectively, to the given filename. Shortcut for\n"
 "     --output-format <format> --output-file <file>\n"
 "  -v: Increase verbosity level (use -vv or more for greater effect)\n"
@@ -1663,6 +1663,7 @@ static int SET_output_format(struct Masscan *masscan, const char *name, const ch
             case Output_Certs:      fprintf(fp, "output-format = certs\n"); break;
             case Output_None:       fprintf(fp, "output-format = none\n"); break;
             case Output_Hostonly:   fprintf(fp, "output-format = hostonly\n"); break;
+            case Output_IPPort:     fprintf(fp, "output-format = ipport\n"); break;
             case Output_Redis:
                 fmt = ipaddress_fmt(masscan->redis.ip);
                 fprintf(fp, "output-format = redis\n");
@@ -1689,6 +1690,7 @@ static int SET_output_format(struct Masscan *masscan, const char *name, const ch
     else if (EQUALS("none", value))         x = Output_None;
     else if (EQUALS("redis", value))        x = Output_Redis;
     else if (EQUALS("hostonly", value))     x = Output_Hostonly;
+    else if (EQUALS("ipport", value))       x = Output_IPPort;
     else {
         LOG(0, "FAIL: unknown output-format: %s\n", value);
         LOG(0, "  hint: 'binary', 'xml', 'grepable', ...\n");
@@ -3429,6 +3431,9 @@ masscan_command_line(struct Masscan *masscan, int argc, char *argv[])
                     break;
                 case 'H':
                     masscan_set_parameter(masscan, "output-format", "hostonly");
+                    break;
+                case 'I':
+                    masscan_set_parameter(masscan, "output-format", "ipport");
                     break;
                 default:
                     fprintf(stderr, "nmap(%s): unknown output format\n", argv[i]);

--- a/src/masscan-version.h
+++ b/src/masscan-version.h
@@ -1,6 +1,6 @@
 #ifndef MASSCAN_VERSION
 
-#define MASSCAN_VERSION "1.3.9-integration"
+#define MASSCAN_VERSION "1.4.0-integration"
 
 #endif
 

--- a/src/masscan.h
+++ b/src/masscan.h
@@ -62,6 +62,7 @@ enum OutputFormat {
     Output_None         = 0x0400,
     Output_Certs        = 0x0800,
     Output_Hostonly     = 0x1000,   /* -oH, "hostonly" */
+    Output_IPPort       = 0x2000,   /* -oI, "ipport" */
     Output_All          = 0xFFBF,   /* not supported */
 };
 

--- a/src/out-ipport.c
+++ b/src/out-ipport.c
@@ -1,0 +1,78 @@
+#include "output.h"
+#include "masscan.h"
+#include "masscan-app.h"
+#include "masscan-status.h"
+#include "unusedparm.h"
+
+#include <ctype.h>
+
+/****************************************************************************
+ ****************************************************************************/
+static void
+ipport_out_open(struct Output *out, FILE *fp)
+{
+    UNUSEDPARM(out);
+    UNUSEDPARM(fp);
+    /* No header */
+}
+
+/****************************************************************************
+ ****************************************************************************/
+static void
+ipport_out_close(struct Output *out, FILE *fp)
+{
+    UNUSEDPARM(out);
+    UNUSEDPARM(fp);
+    /* No footer */
+}
+
+/****************************************************************************
+ ****************************************************************************/
+static void
+ipport_out_status(struct Output *out, FILE *fp, time_t timestamp,
+    int status, ipaddress ip, unsigned ip_proto, unsigned port, unsigned reason, unsigned ttl)
+{
+    ipaddress_formatted_t fmt = ipaddress_fmt(ip);
+    UNUSEDPARM(ttl);
+    UNUSEDPARM(reason);
+    UNUSEDPARM(out);
+    UNUSEDPARM(timestamp);
+    UNUSEDPARM(ip_proto);
+
+    /* Only output open ports */
+    if (status == PortStatus_Open) {
+        fprintf(fp, "%s:%u\n", fmt.string, port);
+    }
+}
+
+/****************************************************************************
+ ****************************************************************************/
+static void
+ipport_out_banner(struct Output *out, FILE *fp, time_t timestamp,
+        ipaddress ip, unsigned ip_proto, unsigned port,
+        enum ApplicationProtocol proto, unsigned ttl,
+        const unsigned char *px, unsigned length)
+{
+    /* For IP:PORT format, we don't output banners */
+    UNUSEDPARM(out);
+    UNUSEDPARM(fp);
+    UNUSEDPARM(timestamp);
+    UNUSEDPARM(ip);
+    UNUSEDPARM(ip_proto);
+    UNUSEDPARM(port);
+    UNUSEDPARM(proto);
+    UNUSEDPARM(ttl);
+    UNUSEDPARM(px);
+    UNUSEDPARM(length);
+}
+
+/****************************************************************************
+ ****************************************************************************/
+const struct OutputType ipport_output = {
+    "ipport",
+    0,
+    ipport_out_open,
+    ipport_out_close,
+    ipport_out_status,
+    ipport_out_banner
+};

--- a/src/output.c
+++ b/src/output.c
@@ -449,6 +449,9 @@ output_create(const struct Masscan *masscan, unsigned thread_index)
     case Output_Hostonly:
         out->funcs = &hostonly_output;
         break;
+    case Output_IPPort:
+        out->funcs = &ipport_output;
+        break;
     case Output_None:
         out->funcs = &null_output;
         break;

--- a/src/output.h
+++ b/src/output.h
@@ -147,6 +147,7 @@ extern const struct OutputType null_output;
 extern const struct OutputType redis_output;
 extern const struct OutputType hostonly_output;
 extern const struct OutputType grepable_output;
+extern const struct OutputType ipport_output;
 
 /**
  * Creates an "output" object. This is called by the receive thread in order

--- a/vs10/masscan.vcxproj
+++ b/vs10/masscan.vcxproj
@@ -49,6 +49,7 @@
     <ClCompile Include="..\src\out-redis.c" />
     <ClCompile Include="..\src\out-tcp-services.c" />
     <ClCompile Include="..\src\out-text.c" />
+    <ClCompile Include="..\src\out-ipport.c" />
     <ClCompile Include="..\src\out-unicornscan.c" />
     <ClCompile Include="..\src\out-xml.c" />
     <ClCompile Include="..\src\pixie-backtrace.c" />

--- a/vs10/masscan.vcxproj.filters
+++ b/vs10/masscan.vcxproj.filters
@@ -96,6 +96,9 @@
     <ClCompile Include="..\src\out-text.c">
       <Filter>Source Files\output</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\out-ipport.c">
+      <Filter>Source Files\output</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\out-xml.c">
       <Filter>Source Files\output</Filter>
     </ClCompile>


### PR DESCRIPTION
## Summary
This PR introduces a new output format called `ipport` to Masscan, which provides a simple list of IP:PORT pairs for open ports. This format is useful for quick parsing and integration with other tools that expect minimal, structured output.

## Changes Made
- **New Output Format**: Added `Output_IPPort` enum value in `masscan.h`.
- **Output Implementation**: Implemented `ipport_output` functions in `src/out-ipport.c` (new file) and registered it in `output.c` and `output.h`.
- **Command Line Support**: Added `-oI` shortcut and `ipport` option to `--output-format` in `main-conf.c`.
- **Documentation**: Updated `README.md` and `doc/masscan.8.markdown` to document the new format.
- **Build Files**: Added `out-ipport.c` to Visual Studio project files (`vs10/masscan.vcxproj` and `vs10/masscan.vcxproj.filters`).
- **Version Bump**: Incremented version to `1.4.0-integration` in `masscan-version.h`.

## Usage Example
```
masscan -p80,443 192.168.1.0/24 --output-format ipport --output-filename results.txt
# Or shorthand:
masscan -p80,443 192.168.1.0/24 -oI results.txt
```

Output format:
```
192.168.1.1:80
192.168.1.2:443
```

## Testing
- Verified compilation on Windows (Visual Studio).
- Tested output generation with sample scans.
- No breaking changes to existing formats.

This enhances Masscan's flexibility for output customization. Please review and merge if approved.